### PR TITLE
Fall back to tslang lib path when locating GC runtime for JIT

### DIFF
--- a/tslang/tslang/jit.cpp
+++ b/tslang/tslang/jit.cpp
@@ -138,36 +138,35 @@ int runJit(int argc, char **argv, mlir::ModuleOp module, CompileOptions &compile
     std::string pathTypeScriptLib("../lib/" LIB_NAME "TypeScriptRuntime." LIB_EXT);
     if (!disableGC.getValue())
     {
-        auto absPath = makeAbsolutePath(pathTypeScriptLib);
-        if (absPath.empty())
-        {            
-            pathTypeScriptLib = LIB_NAME "TypeScriptRuntime." LIB_EXT;
-            auto absPath2 = makeAbsolutePath(pathTypeScriptLib);
-            if (absPath2.empty())
-            {
-                // default lib path
-                auto absPath3 = mergeWithDefaultLibPath(getTslangLibPath(), pathTypeScriptLib);
-                if (absPath3.empty())
+        auto absPath3 = makeAbsolutePath(mergeWithDefaultLibPath(getTslangLibPath(), LIB_NAME "TypeScriptRuntime." LIB_EXT));
+        if (absPath3.empty())
+        {
+            auto absPath = makeAbsolutePath(pathTypeScriptLib);
+            if (absPath.empty())
+            {            
+                pathTypeScriptLib = LIB_NAME "TypeScriptRuntime." LIB_EXT;
+                auto absPath2 = makeAbsolutePath(pathTypeScriptLib);
+                if (absPath2.empty())
                 {
                     /*
                     llvm::WithColor::error(llvm::errs(), "tslang") << "JIT initialization failed. Missing GC library. Did you forget to provide it via "
                                     "'--shared-libs=" LIB_NAME "TypeScriptRuntime." LIB_EXT "'? or you can switch it off by using '-nogc'\n";
                     return -1;            
                     */
-                }     
+                }        
                 else
                 {
-                    clSharedLibs.push_back(absPath3);
+                    clSharedLibs.push_back(absPath2);
                 }
-            }        
+            }
             else
             {
-                clSharedLibs.push_back(absPath2);
+                clSharedLibs.push_back(absPath);
             }
-        }
+        }     
         else
         {
-            clSharedLibs.push_back(absPath);
+            clSharedLibs.push_back(absPath3);
         }
     }
 

--- a/tslang/tslang/jit.cpp
+++ b/tslang/tslang/jit.cpp
@@ -38,6 +38,7 @@ extern cl::opt<std::string> inputFilename;
 extern cl::opt<std::string> TargetTriple;
 
 std::string getDefaultLibPath();
+std::string getTslangLibPath();
 std::string mergeWithDefaultLibPath(std::string, std::string);
 std::string makeAbsolutePath(std::string);
 
@@ -144,11 +145,20 @@ int runJit(int argc, char **argv, mlir::ModuleOp module, CompileOptions &compile
             auto absPath2 = makeAbsolutePath(pathTypeScriptLib);
             if (absPath2.empty())
             {
-                /*
-                llvm::WithColor::error(llvm::errs(), "tslang") << "JIT initialization failed. Missing GC library. Did you forget to provide it via "
-                                "'--shared-libs=" LIB_NAME "TypeScriptRuntime." LIB_EXT "'? or you can switch it off by using '-nogc'\n";
-                return -1;            
-                */
+                // default lib path
+                auto absPath3 = mergeWithDefaultLibPath(getTslangLibPath(), pathTypeScriptLib);
+                if (absPath3.empty())
+                {
+                    /*
+                    llvm::WithColor::error(llvm::errs(), "tslang") << "JIT initialization failed. Missing GC library. Did you forget to provide it via "
+                                    "'--shared-libs=" LIB_NAME "TypeScriptRuntime." LIB_EXT "'? or you can switch it off by using '-nogc'\n";
+                    return -1;            
+                    */
+                }     
+                else
+                {
+                    clSharedLibs.push_back(absPath3);
+                }
             }        
             else
             {


### PR DESCRIPTION
## Summary
- When resolving the GC runtime shared lib for the JIT, if it isn't found under the default lib path, fall back to trying the tslang lib path before giving up.
- Adds `clSharedLibs.push_back(absPath3)` when the fallback resolves successfully instead of silently proceeding without the runtime lib.

## Test plan
- [ ] Run JIT execution tests to confirm GC runtime resolves correctly on this fallback path