### PR TITLE
Reorder JIT section to show source before build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,18 +203,18 @@ The Accounting Department meets each Monday at 10am.
 
 ## Run as JIT
 
-- with Garbage collection
-
-```bat
-tslang hello.ts
-```
-
 File ``hello.ts``
 
 ```typescript
 function main() {
     print("Hello World!");
 }
+```
+
+Build
+
+```bat
+tslang hello.ts
 ```
 
 Result


### PR DESCRIPTION
## Summary
- Moves the `tslang hello.ts` build block in the "Run as JIT" README section to appear after the `hello.ts` source listing, so it reads source → build → result.

## Test plan
- [x] Visual README diff review (docs-only change, no build required)