### PR TITLE
Expose GC disappearing-link and gcollect wrappers

### DIFF
--- a/tslang/include/TypeScript/gcwrapper.h
+++ b/tslang/include/TypeScript/gcwrapper.h
@@ -29,6 +29,12 @@ void *_mlir__GC_malloc_explicitly_typed(size_t size, int64_t descr);
 
 int64_t _mlir__GC_make_descriptor(const int64_t *descr, size_t size);
 
+int _mlir__GC_general_register_disappearing_link(void **link, const void *obj);
+
+int _mlir__GC_unregister_disappearing_link(void **link);
+
+void _mlir__GC_gcollect();
+
 #ifdef __cplusplus
 }
 #endif

--- a/tslang/lib/TypeScriptRuntime/TypeScriptRuntime.def
+++ b/tslang/lib/TypeScriptRuntime/TypeScriptRuntime.def
@@ -19,6 +19,9 @@ EXPORTS
     GC_remove_roots=_mlir__GC_remove_roots
     GC_malloc_explicitly_typed=_mlir__GC_malloc_explicitly_typed
     GC_make_descriptor=_mlir__GC_make_descriptor
+    GC_general_register_disappearing_link=_mlir__GC_general_register_disappearing_link
+    GC_unregister_disappearing_link=_mlir__GC_unregister_disappearing_link
+    GC_gcollect=_mlir__GC_gcollect
 
     ; --- memory runtime (MemRuntime.cpp, extern "C") ---
     _mlir_alloc=Alloc

--- a/tslang/lib/TypeScriptRuntime/gc.cpp
+++ b/tslang/lib/TypeScriptRuntime/gc.cpp
@@ -84,3 +84,18 @@ int64_t _mlir__GC_make_descriptor(const int64_t *descr, size_t size)
 {
     return GC_make_descriptor(reinterpret_cast<const GC_word *>(descr), size);
 }
+
+int _mlir__GC_general_register_disappearing_link(void **link, const void *obj)
+{
+    return GC_general_register_disappearing_link(link, obj);
+}
+
+int _mlir__GC_unregister_disappearing_link(void **link)
+{
+    return GC_unregister_disappearing_link(link);
+}
+
+void _mlir__GC_gcollect()
+{
+    GC_gcollect();
+}


### PR DESCRIPTION
## Summary
- Add `GC_general_register_disappearing_link`, `GC_unregister_disappearing_link`, and `GC_gcollect` wrappers in the runtime GC layer
- Export the new symbols from `TypeScriptRuntime.def`

## Test plan
- [ ] Build TypeScriptRuntime and confirm new exports resolve correctly
- [ ] Exercise disappearing-link registration/unregistration from generated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)