### PR TITLE
Package full defaultlib __build tree in release; update JIT launch config

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -181,7 +181,7 @@ jobs:
         # default library as a whole tree so its per-build subfolders are preserved:
         #   defaultlib/dll/{debug,release}, defaultlib/lib/{debug,release},
         #   defaultlib/*.d.ts, defaultlib/generics/
-        run: Get-ChildItem -Path .\tslang\msbuild\x64\release\bin\tslang.exe, .\tslang\msbuild\x64\release\bin\TypeScriptRuntime.dll, .\gc\msbuild\x64\release\${{ env.BUILD_TYPE }}\gc.lib, .\tslang\msbuild\x64\release\lib\TypeScriptAsyncRuntime.lib, ..\3rdParty\llvm\x64\release\lib\LLVMSupport.lib, ..\3rdParty\llvm\x64\release\bin\wasm-ld.exe, ..\TypeScriptCompilerDefaultLib\__build\defaultlib | Compress-Archive -DestinationPath ..\tslang.zip
+        run: Get-ChildItem -Path .\tslang\msbuild\x64\release\bin\tslang.exe, .\tslang\msbuild\x64\release\bin\TypeScriptRuntime.dll, .\gc\msbuild\x64\release\${{ env.BUILD_TYPE }}\gc.lib, .\tslang\msbuild\x64\release\lib\TypeScriptAsyncRuntime.lib, ..\3rdParty\llvm\x64\release\lib\LLVMSupport.lib, ..\3rdParty\llvm\x64\release\bin\wasm-ld.exe, ..\TypeScriptCompilerDefaultLib\__build | Compress-Archive -DestinationPath ..\tslang.zip
         shell: pwsh
 
       - name: Archive Zip of Windows Asset

--- a/tslang/tslang/.vscode/launch.json
+++ b/tslang/tslang/.vscode/launch.json
@@ -754,11 +754,11 @@
             "program": "${workspaceFolder}/../../__build/tslang/windows-msbuild-2026-debug/bin/tslang.exe",
             "args": [
                 "-emit=jit",
-                "I:/Playground/1.ts",
-                "-debug-only=mlir,llvm",
+                "I:/TypeScriptCompilerDefaultLib/tests/sleep.ts",
+                //"-debug-only=mlir,llvm",
                 "-mlir-disable-threading",
                 "-di",
-                "--default-lib-path=I:/TypeScriptCompilerDefaultLib/__build/debug",
+                "--default-lib-path=I:/TypeScriptCompilerDefaultLib/__build",
                 "--shared-libs=${workspaceFolder}/../../__build/tslang/windows-msbuild-2026-debug/bin/TypeScriptRuntime.dll"
             ],
             "stopAtEntry": false,


### PR DESCRIPTION
@
## Summary
- Archive the entire `__build` defaultlib tree in the release workflow so the per-build subfolders (`dll/lib/{debug,release}`) are preserved, instead of only the `defaultlib` subdir.
- Point the JIT default-lib launch config at the `__build` root instead of `__build/debug`.

Consumers pick the correct `{debug,release}` subfolder at build time, so shipping the whole tree keeps both variants available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@