### PR TITLE
Add design docs: LLVM GC integration and C/C++ header import

### DIFF
--- a/docs/c-cpp-header-import.md
+++ b/docs/c-cpp-header-import.md
@@ -1,0 +1,261 @@
+# C/C++ Library Integration — Converting Headers into tslang Declarations
+
+Estimate and research: how to consume existing C/C++ libraries (`.h`/`.hpp` +
+`.lib`/`.a`/`.dll`/`.so`) from tslang by converting header declarations into the
+compiler's own declaration form, instead of writing `.d.ts` bindings by hand.
+
+---
+
+## 1. What already works today (manual FFI)
+
+The compiler already has a complete *manual* C FFI; every mechanism needed to call
+into a C library exists — only the declaration authoring is manual:
+
+| Mechanism | Where | Notes |
+| --- | --- | --- |
+| `declare function name(args): T` in `.d.ts` | `MLIRGen.cpp` (ambient declarations) | Emits an external `mlir_ts::FuncOp` declaration; the symbol resolves at link/JIT time. The default lib binds dozens of libc functions this way (`strtol`, `strstr`, `toupper`, `localtime`, … in `TypeScriptCompilerDefaultLib/src/native/lib.native.d.ts`, `core/core.os.d.ts`). |
+| `@dllimport` / `@dllexport` decorators | `MLIRGen.cpp` (`InternalFlags::DllImport`), `Defines.h` | Marks a declaration as imported from a DLL (`@dllimport('.')` path form supported). |
+| Struct-by-value via named tuples | e.g. `type tm = [tm_sec: i32, tm_min: i32, ...]` | Tuples lower to LLVM structs; used today for `struct tm` returned by value. |
+| `Reference<T>` | default lib native decls | Out-parameters / `T*` arguments (`strtol(str, end: Reference<string>, ...)`). |
+| `Opaque` type | `TypeScriptTypes.td` (`TypeScript_Opaque`) | Untyped pointer (`void*`) that round-trips through casts. |
+| C varargs | `func.varargs` attribute (`MLIRGen.cpp`) | `declare function printf(format: string, ...args)`-style declarations. |
+| Linking | `tslang.cpp` driver: `-lib=` (static libs, `--emit=exe`), `-obj=` (object files), `-shared-libs=` (JIT), plus `*-lib-path` options | Both AOT (lld) and JIT (ORC symbol resolution) paths exist. |
+
+So "integration with C libraries" reduces to one missing piece: **automatically
+generating the `.d.ts` (or in-memory) declarations from headers** — a bindings
+generator, in the family of Rust `bindgen`, Zig `translate-c`/`@cImport`,
+Swift's ClangImporter, and D's ImportC.
+
+A decisive advantage for this project: **clang is already built in-tree.** The
+3rdParty LLVM build uses `-DLLVM_ENABLE_PROJECTS="clang;lld;mlir"`
+(`scripts/config_llvm_*.bat/sh`), so the clang frontend libraries (and libclang)
+of exactly the matching LLVM version are available with zero new dependencies.
+Parsing C/C++ headers correctly (preprocessor, GNU/MSVC extensions, target ABI
+knowledge) is only realistic with clang; hand-rolled header parsers fail on real
+SDK headers immediately.
+
+## 2. Type mapping: C → tslang
+
+The mapping the generator must implement (all target types already exist in the
+compiler):
+
+| C declaration | tslang declaration | Notes |
+| --- | --- | --- |
+| `int8_t`/`char` (numeric use) | `i8` / `char` | |
+| `uint8_t` … `uint64_t` | `u8`/`u16`/`u32`/`u64` | |
+| `int16_t`/`short`, `int`/`int32_t`, `long long`/`int64_t` | `i16`, `i32` (`int`), `i64` | |
+| `long` | `i32` on Windows, `i64` on Linux | Generator must resolve per target triple — clang's `ASTContext` gives exact widths, never guess from the name. |
+| `size_t`/`ptrdiff_t`/`intptr_t` | `index` | |
+| `float` / `double` | `f32` / `number` (`double`) | |
+| `_Bool`/`bool` | `boolean` | |
+| `const char*` (string semantics) | `string` | tslang `string` lowers to a char pointer (`StringType` → LLVM ptr in `LowerToLLVM.cpp`); zero-terminated, compatible with C. |
+| `T*` (out-param / in-out) | `Reference<T>` | |
+| `void*`, forward-declared `struct S*` (opaque handles) | `Opaque` or a branded `type SHandle = Opaque` | Branding preserves some type safety between different handle types. |
+| `struct S { ... }` (complete, POD) | named tuple `type S = [field1: T1, field2: T2, ...]` | Field order/layout preserved; matches the existing `tm` pattern. |
+| `union` | tuple of the largest member + accessor casts, or `Opaque` | No union type in tslang; acceptable first-cut: expose as opaque bytes. |
+| `enum E { A = 1 }` | `enum E { A = 1 }` | Underlying width from clang. |
+| `#define NAME 42` (object-like macro, literal) | `const NAME = 42` | Via clang's preprocessing record; only literal/`constexpr`-foldable macros; skip function-like macros (report them in a comment). |
+| `typedef` | `type` alias | |
+| Function pointers | function type `(a: T) => R` | Already representable; C callbacks into tslang functions work if the closure has no captured environment (thick-vs-thin function pointer distinction must be checked per site). |
+| `...` varargs | `...args` + `func.varargs` | Already supported. |
+| Bitfields | not representable | Emit the containing struct as opaque + generated accessor functions (phase 2), or skip with a diagnostic. |
+
+## 3. Integration approaches — estimate
+
+### Option A — standalone generator tool `tsbindgen` (recommended first step)
+
+A separate executable (new target under `tslang/`, linked against clang libs from
+3rdParty) that does:
+
+```text
+tsbindgen curl/curl.h -I<include paths> [--filter curl_*] -o curl.d.ts
+```
+
+1. Run clang frontend (`clang::tooling` on the compiler AST level, or the
+   C `libclang` API) over the header with the right target triple/includes.
+2. Walk top-level decls: functions, records, enums, typedefs, macros.
+3. Apply the section-2 mapping; emit a `.d.ts` file (optionally wrapped in a
+   `namespace`/module per header) that users consume with the existing
+   `-lib=curl.lib` linking flags.
+
+- `clang::tooling` + `ASTVisitor` (C++ API) is preferred over `libclang` here:
+  we already build the exact clang version in-tree, so the C++ API's version
+  instability doesn't apply, and it exposes everything (mangled names, exact
+  record layout via `ASTRecordLayout`, macro expansion) that libclang truncates.
+- Output as `.d.ts` text (not binary) so users can inspect/patch it, matching how
+  the default lib is written today.
+
+**Effort: ~3–5 weeks** for production-quality C support (functions, structs,
+enums, typedefs, opaque handles, literal macros, per-target `long`/`size_t`,
+allowlist filtering — real headers pull in thousands of transitive decls, so
+name filtering is a required feature, not a nicety). This yields immediate value:
+bind libcurl, sqlite3, zlib, SDL, most of Win32 `extern "C"` surfaces.
+
+### Option B — in-compiler importer (`import "sqlite3.h"` / `@cImport`) — phase 2
+
+Same mapping logic, but invoked inside the compiler: an import of a `.h` file (or
+a `/// <reference header="..."/>` form) runs clang in-process and materializes
+declarations directly into MLIRGen's symbol tables, skipping `.d.ts` text.
+
+- Best UX (Zig-like), always in sync with the header.
+- Costs: links clang into `tslang.exe` (binary size +~60–100 MB static, mitigable
+  by making it a lazily-loaded shared component or keeping the parse in a
+  `tsbindgen` subprocess with an IPC/temp-file handoff); compile-time cost of
+  parsing headers per build (needs a cache keyed on header + flags hash, like the
+  existing per-build defaultlib layout).
+- **Effort: +3–4 weeks on top of Option A** if A's mapper is written as a reusable
+  library (`TsClangImporter`) from the start — the recommended structure.
+
+### Option C — SWIG / existing generators — not recommended
+
+SWIG, dstep, ctypes-gen etc. target their own runtime models and would need a
+custom backend anyway; writing the clang-based mapper directly (Option A) is less
+work than maintaining a SWIG module, and keeps the exact-version clang advantage.
+
+### Option D — in-process clang → LLVM IR module with declarations (ABI layer)
+
+Idea: run clang inside the compiler over the `.h` file, have it **emit an LLVM IR
+module containing the declarations**, and merge that module into the tslang-produced
+`llvm::Module` (via `llvm::Linker::linkModules`, after MLIR→LLVM translation — the
+transformer hook in `tslang/tslang/transform.cpp` is the natural place).
+
+Two facts shape how this must be done:
+
+1. **A header alone emits nothing.** LLVM IR only contains declarations that are
+   *referenced*; `clang -emit-llvm header.h` produces an empty module. The importer
+   must synthesize a translation unit that references each wanted symbol.
+2. **IR is ABI-lowered — that is both the strength and the limitation.** The
+   clang-emitted declaration for
+   `struct Big f(struct Small s)` is not `Big @f(Small)`; it is e.g.
+   `void @f(ptr sret(%struct.Big), i64)` on SysV or `ptr @f(ptr, ptr)` shapes on
+   Win64, with `sret`/`byval`/coercion attributes. This is exactly the C ABI
+   knowledge we do **not** want to reimplement in the tslang lowering — clang
+   computes it for us, per target, correctly, forever. But the same lowering
+   strips everything the TypeScript **type checker** needs: parameter names,
+   signedness (`unsigned` vs `int` are both `i32`), `char*`-as-string vs
+   byte-buffer, enums, typedefs, macros, struct field names. So an IR-only
+   pipeline cannot produce the `declare function` surface — MLIRGen needs
+   declarations *before* lowering, at type-check time.
+
+Therefore Option D is not an alternative to the AST-based mapping (Options A/B);
+it is the **ABI back-half of the same importer**, and the combination is stronger
+than either half:
+
+```text
+            ┌── AST walk ──► TS declarations (.d.ts or in-memory)  → type checker
+header.h ──►│  in-process clang (one parse)
+            └── CodeGen  ──► LLVM IR module: wrappers + decls      → llvm::Linker
+```
+
+The most robust form of the CodeGen half — and the recommended one — is **wrapper
+emission** rather than raw declaration emission. For each imported function whose
+signature involves anything ABI-sensitive (struct by value, unions, bitfields,
+`long double`, small-struct register splitting), synthesize into the clang TU:
+
+```c
+// generated TU, compiled by in-process clang with the real header
+#include "curl/curl.h"
+__attribute__((used)) CURLcode __ts_curl_easy_setopt(CURL *h, CURLoption o, void *p)
+{ return curl_easy_setopt(h, o, p); }
+// struct-by-value example: tslang always passes/returns via pointer
+__attribute__((used)) void __ts_localtime(const time_t *t, struct tm *out)
+{ *out = *localtime(t); }
+```
+
+tslang then declares and calls only the `__ts_*` wrappers, whose signatures use
+nothing but scalars and pointers — shapes the existing tslang lowering already
+gets right on every target. After `linkModules`, LLVM's inliner collapses the
+wrapper at `-O1+`, so the cost is zero in optimized builds; even at `-O0` it is
+one direct call. Functions with plain scalar/pointer signatures don't need a
+wrapper at all — the AST-side importer declares them directly, as today.
+
+Additional properties of this design:
+
+- **Works in the JIT identically** — the merged module goes through the same ORC
+  path; no extra `.obj` files, no separate compile step for users.
+- **Kills spike-list item 1** (section 5): struct-by-value ABI correctness stops
+  being tslang's problem entirely.
+- **Static inline functions and function-like macros become bindable** — a wrapper
+  around `static inline` code or a macro invocation gives it a real symbol; this
+  is something no declaration-only generator can do, and real headers (Win32,
+  glib, stb_*) are full of both.
+- **C++ phase 1 collapses into the same mechanism**: the wrapper TU is compiled
+  as C++, wrappers call methods/overloads/small templates through ordinary C++
+  code, and export flat `extern "C"`-shaped symbols — no `@linkname`/mangling
+  support needed in the tslang compiler at all (section 4's C++ 2 route becomes
+  the default C++ route, but in-memory, without shipping wrapper `.cpp` files).
+- Cost: links clang CodeGen libraries into the importer host (`tsbindgen` first;
+  the compiler itself only if/when Option B lands), and IR-level linking requires
+  matching target triple + data layout between the clang invocation and the tslang
+  module (drive both from the same `TargetMachine` settings).
+
+**Effort: ~1–2 weeks on top of Option A's AST mapper** (the clang driver setup is
+shared; the additions are wrapper-TU synthesis, `EmitLLVMOnlyAction`, and the
+`linkModules` merge + a flag to dump the merged IR for debugging).
+
+## 4. C++ support — separate, phased problem
+
+C is a 90%-mechanical translation; C++ is not. Realistic phasing:
+
+| Phase | Scope | Approach | Effort |
+| --- | --- | --- | --- |
+| C++ 0 | `extern "C"` blocks in C++ headers | Falls out of Option A for free (clang parses the header as C++, importer takes only C-linkage decls) | included in A |
+| C++ 1 | Free functions, non-template classes with methods (no virtuals crossing the boundary), overloads | Bind by **mangled name**: clang provides Itanium/MSVC mangled symbols (`clang::MangleContext`); emit `declare` per overload with the mangled name attached (needs a small compiler addition: a `@linkname("?foo@@YAHH@Z")` attribute on declarations so the emitted `FuncOp` symbol differs from the TS-visible name). Methods become functions taking `this: Reference<S>` first. Constructors/destructors bound explicitly; caller manages object memory (`GC_malloc_atomic` for PODs / explicit new-delete pair bindings). | 2–4 weeks after A |
+| C++ 2 | Templates, virtual dispatch, exceptions, STL types | **Do not bind directly.** Generate a flattened `extern "C"` wrapper `.cpp` (tsbindgen emits both the wrapper and its `.d.ts`), compiled with the system C++ compiler and linked via existing `-obj=`. Explicit template instantiations only; exceptions caught at the wrapper boundary and converted to error codes (C++ exceptions must never unwind into tslang frames — different personality functions, especially in JIT where Win64 unwind info is custom, see `docs/jit-gc-static-roots.md` context). | 3–6 weeks, per-need |
+
+The C++ ABI reality (mangling differences, MSVC vs Itanium, RTTI, std::string
+layout) is why every successful system (Swift, Rust `cxx` crate, Zig) either uses
+clang as the importer *and* restricts the surface, or generates C wrappers. The
+phase C++ 2 wrapper route is the honest long-term answer for arbitrary C++.
+
+## 5. ABI risk areas to validate early (spike list)
+
+These decide whether generated declarations actually work, and should be a 2–3 day
+spike before committing to the full tool:
+
+1. **Struct-by-value calls** — Win64 passes structs > 8 bytes by hidden pointer,
+   SysV splits into registers. The existing `tm`-by-value binding suggests the
+   MLIR→LLVM lowering already produces plain LLVM struct types and lets LLVM's
+   backend apply C ABI rules — verify against clang-compiled callees for sizes
+   1/2/4/8/9/16/17 bytes on both platforms. Any mismatch means tsbindgen must
+   emit `sret`/byval-shaped signatures itself (clang's `CodeGen` ABI info can be
+   queried for ground truth).
+2. **`long`/`size_t`/`wchar_t` width matrix** per target triple (wasm32 included).
+3. **Callbacks** — passing a tslang function as a C function pointer: confirm a
+   non-capturing function lowers to a bare pointer (captures need trampolines —
+   `TRAMPOLINE_SIZE` in `Defines.h` hints this exists; verify GC interaction, a
+   trampoline allocated by `GC_malloc` handed to a C library outliving the caller
+   is invisible-root territory).
+4. **GC vs C-owned memory** — pointers returned by the library are not GC-scanned
+   objects (fine, Boehm ignores unknown ranges), but a GC pointer stored *into*
+   C-owned memory is invisible to the collector → collected while alive. Rule for
+   generated bindings: parameters that retain pointers must be documented/annotated;
+   provide `GC_add_roots`-style pinning helper in the default lib. (Same class of
+   bug as the JIT statics issue; see `docs/jit-gc-static-roots.md`.)
+5. **JIT path** — `-shared-libs=libcurl.dll` symbol resolution already works for
+   the runtime; confirm generated decls resolve identically under `--emit=jit`
+   (Win32 JIT has custom symbol binding, see `jit.cpp`).
+
+## 6. Recommended plan
+
+1. **Spike (2–3 days):** hand-write `.d.ts` bindings for one real library
+   (sqlite3 is ideal: pure C, opaque handles, callbacks, strings, int64) and run
+   its smoke test AOT + JIT on Windows/Linux. This validates section 5 with zero
+   new code and produces the golden file for the generator.
+2. **`tsbindgen` v1 (3–5 weeks):** clang-tooling-based, C only, allowlist
+   filtering, per-target type resolution, `.d.ts` output; structured as a reusable
+   `TsClangImporter` library + thin CLI. Ship with generated bindings for
+   sqlite3/zlib/curl as tests (curl is already a runtime dependency on Linux).
+3. **ABI layer via clang CodeGen (1–2 weeks, Option D):** wrapper-TU synthesis +
+   `EmitLLVMOnlyAction` + `llvm::Linker::linkModules` merge into the tslang
+   module — removes the struct-by-value ABI risk entirely and makes
+   `static inline` functions and function-like macros bindable.
+4. **C++ phase 1 (2–4 weeks):** simple classes/overloads through the same wrapper
+   mechanism (wrapper TU compiled as C++ exporting flat symbols); the
+   `@linkname` mangled-name route stays as a fallback for wrapper-free binding.
+5. **In-compiler import (3–4 weeks, optional):** `import "header.h"` reusing
+   `TsClangImporter`, with a parse cache.
+
+Total to a genuinely usable "point at a C library and call it" experience:
+**~1–1.5 months** (steps 1–2, with step 3 folded in if struct-heavy APIs matter
+early); full C++ story is incremental on top.

--- a/docs/llvm-gc-integration.md
+++ b/docs/llvm-gc-integration.md
@@ -1,0 +1,196 @@
+# LLVM GC Infrastructure — Integration Estimate for the TypeScript Compiler
+
+Reference: [LLVM Garbage Collection docs](https://llvm.org/docs/GarbageCollection.html)
+
+This document estimates which parts of LLVM's garbage-collection support framework
+(`gc` function attribute, `GCStrategy`, `llvm.gcroot`, `llvm.gcread`/`llvm.gcwrite`,
+`gc.statepoint`, stack maps / `GCMetadataPrinter`) are applicable to the compiler's
+current GC implementation, what each would buy us, and a phased implementation plan.
+
+---
+
+## 1. Current GC implementation (baseline)
+
+The compiler uses **Boehm-Demers-Weiser GC 8.2.12** (`gc-8.2.12.tar.gz` in the repo root)
+as a **conservative, non-moving** collector. Integration today is entirely at the
+allocation-call level — no LLVM GC infrastructure is used:
+
+| Piece | Location | What it does |
+| --- | --- | --- |
+| `GCPass` (MLIR, LLVM dialect level) | `tslang/lib/TypeScript/GCPass.cpp` | Renames `malloc`/`calloc`/`realloc`/`free`/`aligned_alloc` → `GC_malloc`/`GC_malloc_atomic`/`GC_realloc`/`GC_free`/`GC_memalign`; injects `GC_init()` into `main` or the global-ctors function; attaches `allockind("alloc")` + memory-effects attributes so GVN/EarlyCSE at `-O3` do not CSE two allocations into one; removes `memset` after `GC_malloc` (already zeroed). |
+| Runtime wrapper | `tslang/lib/TypeScriptRuntime/gc.cpp`, `TypeScriptGC.cpp`, `tslang/include/TypeScript/gcwrapper.h` | `_mlir__GC_*` wrappers over Boehm: `GC_init`, `GC_malloc[_atomic]`, `GC_memalign`, `GC_realloc`, `GC_free`, `GC_add_roots`/`GC_remove_roots`, typed allocation (`GC_malloc_explicitly_typed`, `GC_make_descriptor`), disappearing links, `GC_gcollect`. |
+| Typed (precise-heap) allocation | `ENABLE_TYPED_GC` in `tslang/include/TypeScript/Config.h` (on by default); `MLIRGen.cpp` (`NewClassInstanceLogicAsOp`), `LowerToLLVM.cpp` (`GCMakeDescriptorOpLowering`, `GCNewExplicitlyTypedOpLowering`) | Class instances are allocated with `GC_malloc_explicitly_typed` using a per-class Boehm descriptor: a generated type-bitmap method feeds `GC_make_descriptor`, and the resulting descriptor is cached in a global so it is built once per class. This gives the heap scan pointer/non-pointer precision for class fields (less false retention); stacks/registers/globals remain conservatively scanned. |
+| JIT static roots | `tslang/tslang/jit.cpp` | JIT-allocated RW data sections are registered via `GC_add_roots` (see `docs/jit-gc-static-roots.md`) because Boehm cannot discover JIT'd sections on its own. |
+
+Properties that follow from Boehm being conservative and non-moving:
+
+- **No stack maps needed** — Boehm scans thread stacks and registers conservatively.
+- **No object relocation** — pointers never move, so no `gc.relocate` semantics are needed.
+- **No read/write barriers required** in the default (stop-the-world, non-incremental) mode.
+- Known weaknesses: false retention (integers that look like pointers), and the risk
+  the LLVM docs explicitly call out — *aggressive optimization can hide the only live
+  copy of a pointer* (kept as an interior/derived value or re-materialized arithmetic),
+  making the object collectable while still in use.
+
+## 2. What LLVM's GC framework provides, piece by piece
+
+| LLVM facility | Purpose | Needed by Boehm? |
+| --- | --- | --- |
+| `gc "name"` attribute + `GCStrategy` plugin | Declares per-function GC strategy; hook for custom lowering and metadata | Not required, but a cheap formalization hook |
+| `llvm.gcroot` | Marks stack slots holding heap references; forces them to be spillable/visible | Not required (conservative stack scan), useful as an anti-"hidden pointer" pin and for shadow-stack targets |
+| `llvm.gcwrite` / `llvm.gcread` | Write/read barrier insertion points, lowered by the strategy | Only if we enable Boehm **incremental/generational** mode with manual dirty-marking |
+| `gc.statepoint` / `gc.relocate` / `gc.result` + `RewriteStatepointsForGC` | Precise safepoints with relocation semantics for **moving** collectors | Not usable with Boehm (non-moving); only relevant if we ever swap the collector |
+| Stack maps + `GCMetadataPrinter` | Emit binary root-location tables per safepoint for the runtime to crawl | Not consumable by Boehm as-is; relevant only for a precise-GC future |
+| `shadow-stack` built-in strategy | Maintains an explicit linked list of roots, no target-specific codegen needed | **Yes for WASM** — the one environment where conservative native-stack scanning is unavailable |
+
+Key framing from the LLVM docs: LLVM ships **no collector**; the framework exists to
+make *accurate* (precise, possibly moving) collection possible. A conservative collector
+like Boehm deliberately needs almost none of it. So the honest estimate is: **most of the
+statepoint/stack-map machinery is not applicable today**, but four pieces are genuinely
+useful, in increasing order of effort:
+
+## 3. Applicability estimate
+
+### 3.1 Custom no-op `GCStrategy` ("tsboehm") — low effort, foundational
+
+Register a strategy and tag every generated function with it:
+
+```cpp
+// in a compiler-linked .cpp (e.g. next to transform.cpp's pipeline setup)
+#include "llvm/IR/GCStrategy.h"
+class TSBoehmGC : public llvm::GCStrategy {
+public:
+    TSBoehmGC() {
+        UseStatepoints = false;
+        UsesMetadata = false;      // no stack maps: Boehm scans conservatively
+        NeededSafePoints = false;
+    }
+};
+static llvm::GCRegistry::Add<TSBoehmGC> X("tsboehm", "Boehm conservative GC for tslang");
+```
+
+and after MLIR→LLVM-IR translation (in `tslang/tslang/transform.cpp`, where the
+`PassBuilder` pipeline is set up):
+
+```cpp
+for (auto &F : *llvmModule)
+    if (!F.isDeclaration())
+        F.setGC("tsboehm");
+```
+
+Benefit: purely declarative today (default strategy behavior = lower intrinsics to
+plain loads/stores, no safepoints, empty stack map), but it is the prerequisite for
+every later step, makes GC-managed functions self-describing in the IR, and lets us
+attach custom lowering later without touching the frontend again.
+
+Estimated effort: **~1 day**, including plumbing the `setGC` loop behind a
+`CompileOptions` flag.
+
+### 3.2 `llvm.gcroot` pinning as mis-optimization insurance — low/medium effort
+
+The one *correctness* risk of Boehm + `-O3` is pointer hiding. A targeted use of
+`llvm.gcroot` (emitted from `LowerToLLVM.cpp` for reference-typed locals, or as an
+LLVM IR pass over the module) forces each GC pointer to live in a real stack slot
+that the conservative scan will see, across every call site. With the default
+(no-op-lowering) strategy in 3.1 this costs a stack spill per rooted value and
+nothing else — no runtime change at all, because Boehm finds the slots by scanning.
+
+Trade-off: defeats `mem2reg`/register promotion for rooted values → measurable
+slowdown in hot loops. Recommendation: implement it, but gate behind
+`--gc-safe-roots` (off by default) and use it as a debugging/hardening tool for
+crashes like the historical JIT statics collection bug rather than as an
+always-on mode.
+
+Estimated effort: **2–4 days** (choosing which MLIR values are reference-like is the
+work; the mechanical part — `alloca` in entry block + `llvm.gcroot` call — is small).
+
+### 3.3 `llvm.gcwrite` → Boehm incremental/generational dirty-marking — medium effort, perf feature
+
+Boehm supports incremental & generational collection (`GC_enable_incremental()`),
+normally driven by OS page protection (slow/fragile on Windows and unavailable under
+some JIT memory managers). Boehm ≥ 8.x offers manual dirty-bit mode
+(`MANUAL_VDB` / `GC_set_manual_vdb_allowed(1)`), where the mutator must call
+`GC_ptr_store_and_dirty(dst, src)` (or `GC_end_stubborn_change`) after pointer stores.
+
+This is exactly what `llvm.gcwrite` + a custom lowering pass is for:
+
+1. Frontend emits `llvm.gcwrite(value, object, slot)` for every store of a reference
+   into a heap object (we know these sites precisely in `LowerToLLVM.cpp` where
+   property/element stores are lowered).
+2. `TSBoehmGC` grows `CustomWriteBarriers = true` plus a lowering pass that rewrites
+   each `gcwrite` to `store` + `call @GC_dirty(slot)` when incremental mode is on,
+   or a plain `store` when it is not (one flag, zero cost in the default build).
+3. Runtime wrapper gains `_mlir__GC_dirty`, plus init-time `GC_set_manual_vdb_allowed(1)`
+   and `GC_enable_incremental()` in `gc.cpp`, exported through
+   `TypeScriptRuntime.def` and `init_gcruntime` like the existing symbols.
+
+Benefit: bounded pause times for large heaps (games/servers), and generational
+collection speedup for allocation-heavy TS code. `llvm.gcread` is **not** needed —
+Boehm's incremental mode requires no read barrier.
+
+Estimated effort: **1–2 weeks** including tests (pause-time test, correctness under
+`-O3`, JIT + AOT, and the shared-lib path via `TypeScriptRuntime.def`).
+
+### 3.4 `shadow-stack` strategy for WASM — medium effort, unblocks a target
+
+On `wasm32` there is no way to conservatively scan the WebAssembly value stack;
+Boehm on WASM only sees the linear-memory "C stack", and misses locals held in wasm
+locals/registers. LLVM's built-in `shadow-stack` strategy solves precisely this:
+each function pushes a frame of its `llvm.gcroot` slots onto an explicit
+`@llvm_gc_root_chain` list — fully portable, no codegen support needed.
+
+Integration sketch (builds on 3.1 + 3.2's root emission):
+
+- For the wasm target, `F.setGC("shadow-stack")` instead of `"tsboehm"`.
+- Emit `llvm.gcroot` for all reference locals (the 3.2 machinery, non-optional here).
+- Runtime: register a Boehm *custom roots* callback (`GC_set_push_other_roots`)
+  that walks `llvm_gc_root_chain` and `GC_push_all`-es each frame's root array.
+
+Estimated effort: **2–3 weeks**, dominated by wasm build/runtime plumbing rather
+than the LLVM side. Only worth doing when the wasm target
+(`prepare_3rdParty_wasm_debug.sh`) becomes a priority.
+
+### 3.5 `gc.statepoint` / stack maps / `GCMetadataPrinter` — not applicable now
+
+These exist to support **precise, moving** collectors (relocation of live references
+across safepoints). Boehm can never consume relocations, and feeding it precise stack
+maps buys little while the heap scan stays conservative. This tier only becomes
+relevant if the project ever replaces Boehm with a precise collector (e.g. MMTk or a
+custom semispace/generational GC). In that world the migration path is:
+`PlaceSafepoints` + `RewriteStatepointsForGC` + a `UsesMetadata`/`UseStatepoints`
+strategy + a `GCMetadataPrinter` emitting our stack-map format, and a new runtime.
+Estimated effort: **multiple months** — record as long-term option only.
+
+Note the LLVM docs' own caveat here: JIT support for the stack-map path is limited,
+and this project relies heavily on the JIT (`jit.cpp` with custom section handling),
+which further weighs against the statepoint route while on Boehm.
+
+## 4. Summary matrix
+
+| Option | LLVM facility | Effort | Benefit | Recommendation |
+| --- | --- | --- | --- | --- |
+| 3.1 `tsboehm` GCStrategy + `setGC` | `GCStrategy`, `gc` attr | ~1 day | Foundation; self-describing IR | Do first |
+| 3.2 `gcroot` pinning (`--gc-safe-roots`) | `llvm.gcroot` | 2–4 days | Correctness insurance vs. pointer-hiding at `-O3`; debugging tool | Do, off by default |
+| 3.3 Write barriers → incremental Boehm | `llvm.gcwrite` + custom lowering | 1–2 weeks | Bounded pauses, generational perf | Do when heap sizes justify it |
+| 3.4 Shadow stack for WASM | `shadow-stack` strategy | 2–3 weeks | Makes GC correct on wasm at all | Tie to wasm-target milestone |
+| 3.5 Statepoints / stack maps | `gc.statepoint`, `GCMetadataPrinter` | months | Only with a moving precise GC | Long-term note only |
+
+Independent of the LLVM framework, heap-side precision is already largely in place:
+with `ENABLE_TYPED_GC` (on by default in `Config.h`), class instances are allocated via
+`GC_malloc_explicitly_typed` with cached per-class `GC_make_descriptor` descriptors, so
+non-pointer class fields are excluded from the scan. Remaining conservative surfaces are
+stacks/registers (addressed by 3.2/3.4), globals, and non-class allocations (arrays,
+strings, closures — strings and other pointer-free data already use `GC_malloc_atomic`
+where the frontend marks them).
+
+## 5. Suggested implementation order
+
+1. **Phase 0 (done)** — typed-allocation descriptors for class instances
+   (`ENABLE_TYPED_GC`, on by default); possible extension: typed descriptors for
+   non-class aggregates (tuples, closures, arrays of references).
+2. **Phase 1** — 3.1 strategy registration + `setGC` plumbing behind a compile option.
+3. **Phase 2** — 3.2 `llvm.gcroot` emission under `--gc-safe-roots`; use it to
+   re-verify the historical JIT/`-O3` GC crashes.
+4. **Phase 3** — 3.3 incremental-mode write barriers, benchmarked on the tester suite
+   (watch the existing `gc_malloc_cse_o3.ts` style tests for optimizer interactions).
+5. **Phase 4 (conditional)** — 3.4 shadow stack when wasm becomes active.


### PR DESCRIPTION
## Summary
- `docs/llvm-gc-integration.md` — estimate of which parts of LLVM's GC framework (GCStrategy, `gc` attribute, `llvm.gcroot`, `llvm.gcwrite`, statepoints/stack maps) are applicable alongside the project's existing Boehm GC, phased by effort/benefit.
- `docs/c-cpp-header-import.md` — plan for converting C/C++ header declarations into tslang declarations, covering an AST-based clang importer (`tsbindgen`), C→tslang type mapping, and an ABI-safe wrapper-emission approach that links a clang-produced LLVM module into the compiler's own module.

## Test plan
- Docs only, no code changes.