### PR TITLE
Emit mustprogress and add --fast-math for loop optimizations/vectorization

### DIFF
--- a/tslang/include/TypeScript/DataStructs.h
+++ b/tslang/include/TypeScript/DataStructs.h
@@ -26,6 +26,7 @@ struct CompileOptions
     std::string outputFolder;
     bool appendGCtorsToMethod;
     bool strictNullChecks;
+    bool enableFastMath;
 };
 
 #endif // TYPESCRIPT_DATASTRUCT_H_

--- a/tslang/lib/TypeScript/LowerToLLVM.cpp
+++ b/tslang/lib/TypeScript/LowerToLLVM.cpp
@@ -1132,6 +1132,14 @@ struct FuncOpLowering : public TsLlvmPattern<mlir_ts::FuncOp>
 
         SmallVector<mlir::Attribute> funcAttrs;
 
+        // mustprogress licenses standard -O2/-O3 loop transforms (LICM, unrolling,
+        // vectorization of provably-finite loops) that otherwise stay conservative
+        // without proof the loop can't spin forever with no observable effect. Every
+        // ts loop with a call/store in its body already satisfies the (weaker)
+        // mustprogress contract; a body-less `while(true){}` is the only case this
+        // attribute changes the meaning of, same as in C/C++/Rust.
+        funcAttrs.push_back(ATTR("mustprogress"));
+
         if (funcOp.getPersonality().has_value() && funcOp.getPersonality().value())
         {
             LLVMRTTIHelperVC rttih(funcOp, rewriter, typeConverter, tsLlvmContext->compileOptions);

--- a/tslang/lib/TypeScript/LowerToLLVM.cpp
+++ b/tslang/lib/TypeScript/LowerToLLVM.cpp
@@ -337,8 +337,9 @@ class IsNaNOpLowering : public TsLlvmPattern<mlir_ts::IsNaNOp>
 
         TypeHelper th(rewriter.getContext());
 
-        // icmp
-        auto cmpValue = rewriter.create<LLVM::FCmpOp>(loc, th.getLLVMBoolType(), LLVM::FCmpPredicate::one,
+        // uno (unordered) self-compare is true iff the value is NaN; `one` here would
+        // be constant false (ordered && x != x can never hold for a self-compare).
+        auto cmpValue = rewriter.create<LLVM::FCmpOp>(loc, th.getLLVMBoolType(), LLVM::FCmpPredicate::uno,
                                                       transformed.getArg(), transformed.getArg());
         rewriter.replaceOp(op, ValueRange{cmpValue});
         return success();
@@ -3043,7 +3044,10 @@ struct LogicalBinaryOpLowering : public TsLlvmPattern<mlir_ts::LogicalBinaryOp>
             break;
         case SyntaxKind::ExclamationEqualsToken:
         case SyntaxKind::ExclamationEqualsEqualsToken:
-            value = logicOp<arith::CmpIPredicate::ne, arith::CmpFPredicate::ONE>(logicalBinaryOp, op, op1, opType1, op2, opType2,
+            // UNE, not ONE: JS `!=`/`!==` is the negation of `==`, so NaN != x must be
+            // true. ONE (ordered) yields false when either side is NaN, and `x != x`
+            // (the idiomatic NaN test) folds to constant false.
+            value = logicOp<arith::CmpIPredicate::ne, arith::CmpFPredicate::UNE>(logicalBinaryOp, op, op1, opType1, op2, opType2,
                                                                    rewriter);
             break;
         case SyntaxKind::GreaterThanToken:

--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -105,7 +105,11 @@ file(REMOVE
     "${CMAKE_CURRENT_BINARY_DIR}/compile.bat"  "${CMAKE_CURRENT_BINARY_DIR}/jit.bat"
     "${CMAKE_CURRENT_BINARY_DIR}/compiled.bat" "${CMAKE_CURRENT_BINARY_DIR}/jitd.bat"
     "${CMAKE_CURRENT_BINARY_DIR}/compile.sh"   "${CMAKE_CURRENT_BINARY_DIR}/jit.sh"
-    "${CMAKE_CURRENT_BINARY_DIR}/compiled.sh"  "${CMAKE_CURRENT_BINARY_DIR}/jitd.sh")
+    "${CMAKE_CURRENT_BINARY_DIR}/compiled.sh"  "${CMAKE_CURRENT_BINARY_DIR}/jitd.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/compilefm.bat" "${CMAKE_CURRENT_BINARY_DIR}/jitfm.bat"
+    "${CMAKE_CURRENT_BINARY_DIR}/compiledfm.bat" "${CMAKE_CURRENT_BINARY_DIR}/jitdfm.bat"
+    "${CMAKE_CURRENT_BINARY_DIR}/compilefm.sh"  "${CMAKE_CURRENT_BINARY_DIR}/jitfm.sh"
+    "${CMAKE_CURRENT_BINARY_DIR}/compiledfm.sh" "${CMAKE_CURRENT_BINARY_DIR}/jitdfm.sh")
 
 ######## enable testing ############
 # open __build\tslang   
@@ -443,6 +447,7 @@ add_test(NAME test-compile-reference-null-bug COMMAND test-runner "${PROJECT_SOU
 add_test(NAME test-compile-reference-index-bug COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_index_bug.ts")
 add_test(NAME test-compile-uint-compare-bug COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00uint_compare_bug.ts")
 add_test(NAME test-compile-gc-malloc-cse-o3 COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/gc_malloc_cse_o3.ts")
+add_test(NAME test-compile-fast-math COMMAND test-runner -fast-math "${PROJECT_SOURCE_DIR}/test/tester/tests/fast_math.ts")
 
 add_test(NAME test-jit-00-print COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00print.ts")
 add_test(NAME test-jit-00-assert COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00assert.ts")
@@ -774,6 +779,7 @@ add_test(NAME test-jit-reference-null-bug COMMAND test-runner -jit "${PROJECT_SO
 add_test(NAME test-jit-reference-index-bug COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_index_bug.ts")
 add_test(NAME test-jit-uint-compare-bug COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00uint_compare_bug.ts")
 add_test(NAME test-jit-gc-malloc-cse-o3 COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/gc_malloc_cse_o3.ts")
+add_test(NAME test-jit-fast-math COMMAND test-runner -jit -fast-math "${PROJECT_SOURCE_DIR}/test/tester/tests/fast_math.ts")
 
 # tesing include
 add_test(NAME test-compile-include-global-var COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/include_global_var.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/define_global_var.ts")

--- a/tslang/test/tester/test-runner.cpp
+++ b/tslang/test/tester/test-runner.cpp
@@ -99,17 +99,32 @@ auto tslang_opt = "--di --opt_level=0 --no-default-lib";
 #define COMPILE_NAME "compiled"
 #endif
 
+auto fastMath = false;
 auto tslang_opt_ext = std::string("");
+
+// -fast-math tests get their own cached script (jitfm/compilefm) because the
+// plain jit/compile scripts are shared across all parallel single-file tests
+// and embed tslang_opt_ext at creation time - reusing the same file name would
+// let whichever runner created it first decide the flags for everyone.
+std::string jitBatName()
+{
+    return std::string(JIT_NAME) + (fastMath ? "fm" : "") + BAT_NAME;
+}
+
+std::string compileBatName()
+{
+    return std::string(COMPILE_NAME) + (fastMath ? "fm" : "") + BAT_NAME;
+}
 
 void createJitBatchFile()
 {
-#ifdef WIN32    
-    if (exists(JIT_NAME BAT_NAME))
+#ifdef WIN32
+    if (exists(jitBatName()))
     {
         return;
     }
 
-    std::ofstream batFile(JIT_NAME BAT_NAME);
+    std::ofstream batFile(jitBatName());
     batFile << "echo off" << std::endl;
     batFile << "set FILENAME=%1" << std::endl;
     batFile << "set FILEPATH=%2" << std::endl;
@@ -119,12 +134,12 @@ void createJitBatchFile()
             << std::endl;
     batFile.close();
 #else
-    if (exists(JIT_NAME BAT_NAME))
+    if (exists(jitBatName()))
     {
         return;
     }
 
-    std::ofstream batFile(JIT_NAME BAT_NAME);
+    std::ofstream batFile(jitBatName());
     batFile << "FILENAME=$1" << std::endl;
     batFile << "FILEPATH=$2" << std::endl;
     batFile << "TSLANGEXEPATH=" << TEST_TSLANG_EXEPATH << std::endl;
@@ -136,13 +151,13 @@ void createJitBatchFile()
 
 void createCompileBatchFile()
 {
-#ifdef WIN32     
-    if (exists(COMPILE_NAME BAT_NAME))
+#ifdef WIN32
+    if (exists(compileBatName()))
     {
         return;
     }
 
-    std::ofstream batFile(COMPILE_NAME BAT_NAME);
+    std::ofstream batFile(compileBatName());
     batFile << "echo off" << std::endl;
     batFile << "set FILENAME=%1" << std::endl;
     batFile << "set FILEPATH=%2" << std::endl;
@@ -169,12 +184,12 @@ void createCompileBatchFile()
     batFile << "echo on" << std::endl;
     batFile.close();
 #else
-    if (exists(COMPILE_NAME BAT_NAME))
+    if (exists(compileBatName()))
     {
         return;
     }
 
-    std::ofstream batFile(COMPILE_NAME BAT_NAME);
+    std::ofstream batFile(compileBatName());
     batFile << "FILENAME=$1" << std::endl;
     batFile << "FILEPATH=$2" << std::endl;
     batFile << "LINKER_OPTS=$3" << std::endl;
@@ -207,12 +222,12 @@ void createBatchFile()
 
 void buildJitExecCommand(std::stringstream &ss, std::string fileNameNoExt, std::string file)
 {
-    ss << RUN_CMD << JIT_NAME BAT_NAME << " " << fileNameNoExt << " " << file;
+    ss << RUN_CMD << jitBatName() << " " << fileNameNoExt << " " << file;
 }
 
 void buildCompileExecCommand(std::stringstream &ss, std::string fileNameNoExt, std::string file)
 {
-    ss << RUN_CMD << COMPILE_NAME BAT_NAME << " " << fileNameNoExt << " " << file;
+    ss << RUN_CMD << compileBatName() << " " << fileNameNoExt << " " << file;
     if (sharedLib)
     {
         ss << SHARED_LIB_OPT;
@@ -663,6 +678,11 @@ void readParams(int argc, char **argv, std::vector<std::string> &files)
         else if (std::string(argv[index]) == "-noopt")
         {
             opt = false;
+        }
+        else if (std::string(argv[index]) == "-fast-math")
+        {
+            fastMath = true;
+            tslang_opt_ext += " --fast-math";
         }
         else if (exists(argv[index]))
         {

--- a/tslang/test/tester/tests/02numbers.ts
+++ b/tslang/test/tester/tests/02numbers.ts
@@ -202,8 +202,12 @@ function testComma() {
     assert(y.length == 4, "y");
 }
 
+// NaN is the only value not strictly equal to itself: `NaN !== NaN` is true and
+// `NaN === NaN` is false per ECMAScript. The previous form
+// `(x !== x) === (x === x)` is always false in conforming JS and only passed
+// while `!==` was mis-lowered to an ordered (ONE) float compare.
 function isnan(x: number) {
-    return (x !== x) === (x === x);
+    return x !== x;
 }
 
 function mydiv(x: number, y: number) {

--- a/tslang/test/tester/tests/fast_math.ts
+++ b/tslang/test/tester/tests/fast_math.ts
@@ -1,0 +1,85 @@
+// Run by test-compile-fast-math / test-jit-fast-math with the extra --fast-math
+// compiler flag (see test-runner -fast-math). Verifies that the relaxed
+// floating-point mode keeps the language semantics it promises to keep:
+//
+// 1. FP loop reductions still compute correct results. All values below are
+//    exact multiples of 0.125, so every partial sum is exactly representable
+//    and reassociation (the transform --fast-math licenses, and what the -O3
+//    vectorizer uses to turn the loop into SIMD lanes) cannot change the
+//    result - exact equality asserts stay valid.
+// 2. NaN and Infinity semantics survive: --fast-math deliberately omits
+//    nnan/ninf, so `x !== x` NaN checks and Infinity arithmetic keep working.
+// 3. Plain counted integer loops are unaffected.
+
+function isnan(x: number) {
+    return x !== x;
+}
+
+function fpReduction(n: int): number {
+    let arr: number[] = [];
+    for (let i = 0; i < n; i++) {
+        arr.push((i % 10) * 0.125);
+    }
+
+    let sum: number = 0.0;
+    for (let i = 0; i < n; i++) {
+        sum = sum + arr[i];
+    }
+
+    return sum;
+}
+
+function dotProduct(n: int): number {
+    let a: number[] = [];
+    let b: number[] = [];
+    for (let i = 0; i < n; i++) {
+        a.push((i % 8) * 0.25);
+        b.push(((i + 1) % 4) * 0.5);
+    }
+
+    let sum: number = 0.0;
+    for (let i = 0; i < n; i++) {
+        sum = sum + a[i] * b[i];
+    }
+
+    return sum;
+}
+
+function intTriangle(n: int): int {
+    let s: int = 0;
+    for (let i: int = 1; i <= n; i++) {
+        s = s + i;
+    }
+
+    return s;
+}
+
+function testNaNAndInfinity() {
+    const zero: number = fpReduction(10) - 5.625; // 0.0, computed at runtime
+    const nan = zero / zero;
+    assert(nan !== nan, "NaN !== NaN must stay true under --fast-math");
+    assert(!(nan === nan), "NaN === NaN must stay false under --fast-math");
+    assert(isnan(nan), "isnan(0/0)");
+    assert(!isnan(1.5), "!isnan(1.5)");
+    assert(!isnan(zero), "!isnan(0)");
+
+    const inf = 1.0 / zero;
+    assert(!isnan(inf), "Infinity is not NaN");
+    assert(inf > 1.0e308, "Infinity compares greater than any finite double");
+    assert(1.0 / inf === 0.0, "1/Infinity === 0");
+    assert(-inf < -1.0e308, "-Infinity stays representable");
+}
+
+function main() {
+    // per 10 elements: (0+1+...+9)*0.125 = 5.625; 100 groups
+    assert(fpReduction(1000) === 562.5, "fp sum reduction");
+
+    // per 8 elements the products sum to exactly 5.0; 100 cycles
+    assert(dotProduct(800) === 500.0, "fp dot product");
+
+    assert(intTriangle(1000) === 500500, "integer counted loop");
+
+    testNaNAndInfinity();
+
+    print("done.");
+}

--- a/tslang/tslang/opts.cpp
+++ b/tslang/tslang/opts.cpp
@@ -25,8 +25,9 @@ extern cl::opt<bool> enableBuiltins;
 extern cl::opt<bool> noDefaultLib;
 extern cl::opt<std::string> outputFilename;
 extern cl::opt<bool> appendGCtorsToMethod;
-extern cl::opt<bool> strictNullChecks; 
+extern cl::opt<bool> strictNullChecks;
 extern cl::opt<bool> embedExportDeclarationsAction;
+extern cl::opt<bool> enableFastMath;
 
 // obj
 extern cl::opt<std::string> TargetTriple;
@@ -57,6 +58,7 @@ CompileOptions prepareOptions()
     compileOptions.isDLL = emitAction == Action::BuildDll;
     compileOptions.appendGCtorsToMethod = appendGCtorsToMethod.getValue();
     compileOptions.strictNullChecks = strictNullChecks.getValue();
+    compileOptions.enableFastMath = enableFastMath.getValue();
     if (
         TheTriple.getArch() == llvm::Triple::UnknownArch
         || TheTriple.getArch() == llvm::Triple::aarch64        // AArch64 (little endian): aarch64

--- a/tslang/tslang/transform.cpp
+++ b/tslang/tslang/transform.cpp
@@ -40,6 +40,11 @@
 
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/CodeGen/CommandFlags.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Target/TargetMachine.h"
 #include "llvm/Passes/OptimizationLevel.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
@@ -217,6 +222,44 @@ static std::optional<llvm::OptimizationLevel> mapToLevel(unsigned optLevel, unsi
     return std::nullopt;
 }
 
+// --fast-math: relax IEEE-754 strictness the same way clang's
+// -funsafe-math-optimizations does, but deliberately WITHOUT nnan/ninf
+// (finite-math-only). In TypeScript NaN and Infinity are first-class values
+// produced in ordinary control flow (Number('abc'), parseFloat failures,
+// overflow), and the default lib's isNaN/isFinite are `x !== x`-style checks
+// that nnan would constant-fold away. reassoc+nsz is what actually licenses
+// FP-reduction vectorization; arcp/contract/afn add reciprocal, FMA
+// contraction, and approximate libm calls.
+static void applyFastMathFlags(llvm::Module &m)
+{
+    for (auto &func : m)
+    {
+        if (func.isDeclaration())
+        {
+            continue;
+        }
+
+        // backend (SelectionDAG/GlobalISel) counterparts of the IR flags
+        func.addFnAttr("unsafe-fp-math", "true");
+        func.addFnAttr("no-signed-zeros-fp-math", "true");
+        func.addFnAttr("approx-func-fp-math", "true");
+
+        for (auto &inst : llvm::instructions(func))
+        {
+            if (llvm::isa<llvm::FPMathOperator>(&inst))
+            {
+                auto fmf = inst.getFastMathFlags();
+                fmf.setAllowReassoc();
+                fmf.setNoSignedZeros();
+                fmf.setAllowReciprocal();
+                fmf.setAllowContract();
+                fmf.setApproxFunc();
+                inst.setFastMathFlags(fmf);
+            }
+        }
+    }
+}
+
 std::function<llvm::Error(llvm::Module *)> makeCustomPassesWithOptimizingTransformer(
     std::optional<unsigned> mbOptLevel, std::optional<unsigned> mbSizeLevel, llvm::TargetMachine *targetMachine, CompileOptions &compileOptions)
 {
@@ -230,12 +273,36 @@ std::function<llvm::Error(llvm::Module *)> makeCustomPassesWithOptimizingTransfo
                 llvm::inconvertibleErrorCode());
         }
 
+        if (compileOptions.enableFastMath)
+        {
+            applyFastMathFlags(*m);
+        }
+
+        // Every caller hands in a null TargetMachine, which leaves the -O2/-O3
+        // cost model without target information: no vector registers are known,
+        // so LoopVectorize/SLP never consider vectorization profitable. Build a
+        // TargetMachine from the module triple (honoring -mcpu/-mattr) so the
+        // optimization pipeline sees the real target.
+        std::unique_ptr<llvm::TargetMachine> ownedTargetMachine;
+        auto *effectiveTargetMachine = targetMachine;
+        if (!effectiveTargetMachine)
+        {
+            std::string lookupError;
+            if (auto *target = llvm::TargetRegistry::lookupTarget(m->getTargetTriple(), lookupError))
+            {
+                ownedTargetMachine.reset(target->createTargetMachine(
+                    m->getTargetTriple(), llvm::codegen::getCPUStr(), llvm::codegen::getFeaturesStr(),
+                    llvm::TargetOptions(), std::nullopt));
+                effectiveTargetMachine = ownedTargetMachine.get();
+            }
+        }
+
         llvm::LoopAnalysisManager lam;
         llvm::FunctionAnalysisManager fam;
         llvm::CGSCCAnalysisManager cgam;
         llvm::ModuleAnalysisManager mam;
 
-        llvm::PassBuilder pb(targetMachine);
+        llvm::PassBuilder pb(effectiveTargetMachine);
 
         pb.registerModuleAnalyses(mam);
         pb.registerCGSCCAnalyses(cgam);

--- a/tslang/tslang/tslang.cpp
+++ b/tslang/tslang/tslang.cpp
@@ -137,7 +137,10 @@ cl::opt<bool> noDefaultLib("no-default-lib", cl::desc("Disable loading default l
 cl::opt<bool> enableBuiltins("builtins", cl::desc("Builtin functionality (needed if Default lib is not provided)"), cl::init(true), cl::cat(TypeScriptCompilerCategory));
 cl::opt<bool> appendGCtorsToMethod("gctors-as-method", cl::desc("Creeate method (" MLIR_GCTORS ") to initialize Static Objects instead of Global Constructors (gctors)"), cl::init(false), cl::cat(TypeScriptCompilerCategory));
 
-cl::opt<bool> strictNullChecks("strict-null-checks", cl::desc("Strict Null Checks"), cl::init(true), cl::cat(TypeScriptCompilerCategory)); 
+cl::opt<bool> strictNullChecks("strict-null-checks", cl::desc("Strict Null Checks"), cl::init(true), cl::cat(TypeScriptCompilerCategory));
+
+cl::opt<bool> enableFastMath("fast-math", cl::desc("Allow aggressive floating-point optimizations (reassociation, reciprocal, FMA contraction, approximate math functions). "
+                                                   "May change results of floating-point computations; NaN and Infinity semantics are preserved."), cl::init(false), cl::cat(TypeScriptCompilerCategory));
 
 cl::opt<bool> newVSCodeFolder("new", cl::desc("New VS Code Project"), cl::cat(TypeScriptCompilerCategory));
 cl::opt<bool> newCMakeFolder("cmake", cl::desc("New CMake Project"), cl::cat(TypeScriptCompilerCategory));


### PR DESCRIPTION
## Summary

Two codegen improvements that unlock LLVM's loop optimizations, plus correctness fixes found while validating them.

### mustprogress on lowered functions
Lowered functions carried no LLVM function attributes at all. Without `mustprogress`, the -O2/-O3 loop passes (LICM, unrolling, dead-loop elimination) must conservatively assume any loop may spin forever with no observable effect. Verified with an isolated integer-bounded reduction loop that -O3 previously neither unrolled nor removed when dead.

### --fast-math option (opt-in, off by default)
Applies `reassoc nsz arcp contract afn` fast-math flags to all FP instructions plus matching backend function attributes, before the LLVM optimization pipeline, on every emit path (exe/obj/jit/llvm).

**Deliberately excludes `nnan`/`ninf`**: NaN and Infinity are first-class TypeScript values (`Number("abc")`, `0/0`, overflow), so `--fast-math` relaxes precision (reassociation, FMA contraction, reciprocal, approx libm) without breaking `x !== x` NaN checks — verified in optimized IR.

With the flag, a `sum += arr[i]` double reduction now compiles to `<2 x double>` wide loads with dual accumulators and `llvm.vector.reduce.fadd`; without it, codegen stays scalar and IEEE-exact.

### PassBuilder now gets a real TargetMachine
All callers passed `targetMachine=nullptr` to `PassBuilder`, so the -O3 cost model had no target info — no vector registers known, vectorization never profitable, for anyone. The transformer now builds a TargetMachine from the module triple (honoring `-mcpu`/`-mattr`). Benefits all optimized builds independent of fast-math.

### NaN predicate correctness fixes (pre-existing bugs)
- Float `!=`/`!==` lowered as `fcmp one` (ordered): per ECMAScript `NaN != x` must be `true` → fixed to `une`. Previously `x !== x` (the idiomatic NaN test) folded to constant `false` at -O3.
- `IsNaNOp` lowered as `fcmp one x, x`, which is constant false for every input → fixed to `fcmp uno`.
- `02numbers.ts` had codified the buggy behavior (its `isnan` helper `(x !== x) === (x === x)` is always false in conforming JS); corrected to the standard `x !== x` idiom.

### New tests
`fast_math.ts` (compile + jit, run with the new `test-runner -fast-math` mode which uses separately-cached `jitfm`/`compilefm` scripts to avoid poisoning the shared script cache under parallel ctest):
- FP sum reduction and dot product using exact multiples of 0.125, so every partial sum is exactly representable and reassociation cannot change the result — exact-equality asserts remain valid while exercising the vectorized codepath (verified 14 `vector.body` blocks in the compiled test).
- NaN/Infinity semantics under `--fast-math` (the no-nnan/ninf guarantee).
- Integer counted loop unaffected.

## Test plan
- Full suite: **683/683 pass** (compile + JIT), including the 2 new fast-math tests.
- Manually verified vectorized IR with `--fast-math` and scalar IEEE-exact IR without it.
- Verified NaN checks survive -O3 in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)