### PR TITLE
Make GenContext cleanup pointers non-owning

### DIFF
--- a/tslang/include/TypeScript/MLIRLogic/MLIRGenContext.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRGenContext.h
@@ -75,11 +75,12 @@ struct GenContext
         receiverFuncType = mlir::Type();
     }
 
-    // TODO: you are using "theModule.getBody()->clear();", do you need this hack anymore?
+    // erases the IR collected during a dummy run (cleanup lists, dummy funcOp) and detaches from it;
+    // the lists, passResult and state are owned by the stack frame that set them, not by GenContext
     void clean()
     {
         if (cleanUps)
-        {    
+        {
             for (auto op : *cleanUps)
             {
                 op->dropAllDefinedValueUses();
@@ -88,7 +89,7 @@ struct GenContext
                 op->erase();
             }
 
-            delete cleanUps;
+            cleanUps->clear();
             cleanUps = nullptr;
         }
 
@@ -102,28 +103,14 @@ struct GenContext
                 op->erase();
             }
 
-            delete cleanUpOps;
-            cleanUpOps = nullptr;               
+            cleanUpOps->clear();
+            cleanUpOps = nullptr;
         }
 
-        if (passResult)
-        {
-            delete passResult;
-            passResult = nullptr;
-        }
-
-        cleanState();
+        passResult = nullptr;
+        state = nullptr;
 
         cleanFuncOp();
-    }
-
-    void cleanState()
-    {
-        if (state)
-        {
-            delete state;
-            state = nullptr;
-        }
     }
 
     void cleanFuncOp()

--- a/tslang/lib/TypeScript/MLIRGen.cpp
+++ b/tslang/lib/TypeScript/MLIRGen.cpp
@@ -764,9 +764,6 @@ class MLIRGenImpl
         genContextPartial.dummyRun = true;
         genContextPartial.rootContext = &genContextPartial;
         genContextPartial.postponedMessages = &postponedMessages;
-        // TODO: no need to clean up here as whole module will be removed
-        //genContextPartial.cleanUps = new mlir::SmallVector<mlir::Block *>();
-        //genContextPartial.cleanUpOps = new mlir::SmallVector<mlir::Operation *>();
 
         for (auto includeFile : includeFiles)
         {
@@ -780,8 +777,6 @@ class MLIRGenImpl
         }
 
         auto notResolved = processStatements(module->statements, genContextPartial);
-
-        genContextPartial.clean();
 
         // clean up: erase only the ops this discovery pass added, preserving any content that
         // was already generated before a nested discovery (see preExistingOps above).
@@ -5557,16 +5552,22 @@ class MLIRGenImpl
             llvm::ScopedHashTableScope<StringRef, VariableDeclarationDOM::TypePtr> 
                 fullNameGlobalsMapScope(fullNameGlobalsMap);
 
+            // owned here; GenContext borrows pointers to them (see GenContext::clean)
+            SmallVector<mlir::Block *> cleanUpsList;
+            SmallVector<mlir::Operation *> cleanUpOpsList;
+            PassResult passResultData;
+            int discoverState = 1;
+
             GenContext genContextWithPassResult{};
             genContextWithPassResult.funcOp = dummyFuncOp;
             genContextWithPassResult.thisType = genContext.thisType;
             genContextWithPassResult.thisClassType = genContext.thisClassType;
             genContextWithPassResult.allowPartialResolve = true;
             genContextWithPassResult.dummyRun = true;
-            genContextWithPassResult.cleanUps = new SmallVector<mlir::Block *>();
-            genContextWithPassResult.cleanUpOps = new SmallVector<mlir::Operation *>();
-            genContextWithPassResult.passResult = new PassResult();
-            genContextWithPassResult.state = new int(1);
+            genContextWithPassResult.cleanUps = &cleanUpsList;
+            genContextWithPassResult.cleanUpOps = &cleanUpOpsList;
+            genContextWithPassResult.passResult = &passResultData;
+            genContextWithPassResult.state = &discoverState;
             genContextWithPassResult.allocateVarsInContextThis =
                 (functionLikeDeclarationBaseAST->internalFlags & InternalFlags::VarsInObjectContext) ==
                 InternalFlags::VarsInObjectContext;
@@ -6091,7 +6092,8 @@ class MLIRGenImpl
         auto funcGenContext = GenContext(funcDeclGenContext);
         funcGenContext.clearScopeVars();
         funcGenContext.funcOp = funcOp;
-        funcGenContext.state = new int(1);
+        int funcState = 1;
+        funcGenContext.state = &funcState;
         // if funcGenContext.passResult is null and allocateVarsInContextThis is true, this type should contain fully
         // defined object with local variables as fields
         funcGenContext.allocateVarsInContextThis =
@@ -6123,8 +6125,6 @@ class MLIRGenImpl
             resultFromBody = mlirGenFunctionBody(
                 functionLikeDeclarationBaseAST, funcProto->getNameWithoutNamespace(), funcOp, funcProto, funcGenContext);
         }
-
-        funcGenContext.cleanState();
 
         if (mlir::failed(resultFromBody))
         {


### PR DESCRIPTION
## Summary

Implements the ownership half of item A1 from `docs/MLIRGen-refactoring-review.md`.

`GenContext` held raw owning pointers (`cleanUps`, `cleanUpOps`, `passResult`, `state`) freed manually via `clean()`/`cleanState()`, while the struct is copied ~48× and copies share those pointers — a leak on any early-return path and a latent double-delete if `clean()` ever ran through two copies.

- The two setup sites now **stack-allocate** the objects — the discovery run (`SmallVector`s + `PassResult` + `state` in `mlirGenFunctionEntry`'s discovery block) and the per-function `state` counter — and `GenContext` only borrows pointers to them. Declaration order guarantees the owners outlive every context copy in the call subtree.
- `GenContext::clean()` keeps its real job — erasing IR collected during a dummy run and the dummy `funcOp` — but no longer frees memory; it clears the borrowed lists and detaches. `cleanState()` is removed entirely.
- Removed the stale no-op `clean()` call and commented-out allocations in `mlirDiscoverAllDependencies` (that context never allocated cleanup lists nor set `funcOp`, so the call did nothing).

Net effect: memory lifetime is structural (stack unwinding), while the three explicit `clean()` calls remain for their IR-erasure side effect only.

## Test plan

- `tslang` rebuilt cleanly (vs2026 debug)
- New smoke test driving exactly the changed paths — function return-type **discovery** (dummy run with stack-owned `PassResult`) and **closure capture** (`outerVariables`) — JIT output `3 42` as expected
- Prior smoke tests for #201–#203 paths unchanged (`42 15 42 3 1`, `5 21 7 x`, and the utility-type/spread/push suite)
- `MLIRGenTests.exe`: 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)