### PR TITLE
Store function signatures instead of FuncOp handles in functionMap (§2)

### DIFF
--- a/tslang/include/TypeScript/MLIRLogic/MLIRGenStore.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRGenStore.h
@@ -985,6 +985,20 @@ struct GenericClassInfo
     }
 };
 
+// what we know about a registered function; deliberately not the FuncOp itself -
+// discovery-pass ops are erased with the discovery module, so cached op handles dangle.
+// Resolve a live op through theModule.lookupSymbol when one is actually needed.
+struct FunctionEntry
+{
+    std::string name;
+    mlir_ts::FunctionType funcType;
+
+    explicit operator bool() const
+    {
+        return static_cast<bool>(funcType);
+    }
+};
+
 struct NamespaceInfo
 {
   public:
@@ -998,7 +1012,7 @@ struct NamespaceInfo
 
     llvm::StringMap<mlir_ts::FunctionType> functionTypeMap;
 
-    llvm::StringMap<mlir_ts::FuncOp> functionMap;
+    llvm::StringMap<FunctionEntry> functionMap;
 
     llvm::StringMap<GenericFunctionInfo::TypePtr> genericFunctionMap;
 

--- a/tslang/lib/TypeScript/MLIRGen.cpp
+++ b/tslang/lib/TypeScript/MLIRGen.cpp
@@ -5312,7 +5312,7 @@ class MLIRGenImpl
         auto funcIt = getFunctionMap().find(name);
         if (funcIt != getFunctionMap().end())
         {
-            auto cachedFuncType = funcIt->second.getFunctionType();
+            auto cachedFuncType = funcIt->second.funcType;
             if (cachedFuncType.getNumResults() > 0)
             {
                 auto returnType = cachedFuncType.getResult(0);
@@ -6032,7 +6032,8 @@ class MLIRGenImpl
         auto name = funcProto->getNameWithoutNamespace();
         if (!getFunctionMap().count(name))
         {
-            getFunctionMap().insert({name, funcOp});
+            getFunctionMap().insert(
+                {name, FunctionEntry{funcOp.getName().str(), mlir::cast<mlir_ts::FunctionType>(funcOp.getFunctionType())}});
 
             LLVM_DEBUG(llvm::dbgs() << "\n!! reg. func: " << name << " type:" << funcOp.getFunctionType() << " function name: " << funcProto->getName()
                                     << " num inputs:" << mlir::cast<mlir_ts::FunctionType>(funcOp.getFunctionType()).getNumInputs()
@@ -6081,10 +6082,18 @@ class MLIRGenImpl
         {
             auto [fullFunctionName, functionName] = getNameOfFunction(functionLikeDeclarationBaseAST, funcDeclGenContext);
 
-            auto funcOp = lookupFunctionMap(functionName);
-            if (funcOp && theModule.lookupSymbol(functionName) 
+            auto funcEntry = lookupFunctionMap(functionName);
+            if (funcEntry && theModule.lookupSymbol(functionName)
                 || theModule.lookupSymbol(fullFunctionName))
             {
+                // resolve a live op from the module instead of returning a cached handle;
+                // the registered symbol is usually the full name
+                auto funcOp = theModule.lookupSymbol<mlir_ts::FuncOp>(functionName);
+                if (!funcOp)
+                {
+                    funcOp = theModule.lookupSymbol<mlir_ts::FuncOp>(fullFunctionName);
+                }
+
                 return {mlir::success(), funcOp, functionName, false};
             }
         }
@@ -15966,11 +15975,8 @@ class MLIRGenImpl
         auto fn = getFunctionMap().find(name);
         if (fn != getFunctionMap().end())
         {
-            auto funcOp = fn->getValue();
-            auto funcType = funcOp.getFunctionType();
-            auto funcName = funcOp.getName();
-
-            return resolveFunctionWithCapture(location, funcName, funcType, mlir::Value(), false, genContext);
+            auto &funcEntry = fn->getValue();
+            return resolveFunctionWithCapture(location, funcEntry.name, funcEntry.funcType, mlir::Value(), false, genContext);
         }
 
         return mlir::Value();
@@ -26273,12 +26279,12 @@ genContext);
         lookupLogic(functionTypeMap);
     }
 
-    auto getFunctionMap() -> llvm::StringMap<mlir_ts::FuncOp> &
+    auto getFunctionMap() -> llvm::StringMap<FunctionEntry> &
     {
         return currentNamespace->functionMap;
     }
 
-    auto lookupFunctionMap(StringRef name) -> mlir_ts::FuncOp
+    auto lookupFunctionMap(StringRef name) -> FunctionEntry
     {
         lookupLogic(functionMap);
     }


### PR DESCRIPTION
## Summary

Implements §2 from `docs/MLIRGen-refactoring-review.md` for `NamespaceInfo::functionMap`.

The map cached raw `mlir_ts::FuncOp` handles. Since #213 routed the discovery pass into a throwaway module, any handle registered during discovery is *guaranteed* to dangle once that module is erased — consumers survived only because they read the (MLIRContext-owned, always-safe) function type early. Now:

- `functionMap` stores a **`FunctionEntry` { symbol name (`std::string` — a `StringRef` would dangle with the op's attribute storage), `mlir_ts::FunctionType` }**, which is everything any consumer actually used.
- The one site that needs a live op — the generic-instantiation short-circuit in `mlirGenFunctionLikeDeclaration` — resolves it through `theModule.lookupSymbol<mlir_ts::FuncOp>` with a short-name → full-name fallback, so it returns an op from the *current* module rather than a possibly-stale cached handle.

## Test plan

The full suite earned its keep here: the **first** full run caught a real regression — my initial short-circuit rewrite resolved by short name only, returning null where the original returned the cached (full-symbol) op, failing `funcs-nesting-capture` and `any-generic-equals` in both compile and JIT modes. The fallback fixed it.

- Final run: **683/683 ctest tests passed** (152 s, `-j8`) — full AOT + JIT + unittests
- The four previously failed tests pass individually as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)