### PR TITLE
Fix non-converging generic parameter inference loop (A3)

### DIFF
--- a/tslang/lib/TypeScript/MLIRGen.cpp
+++ b/tslang/lib/TypeScript/MLIRGen.cpp
@@ -2577,15 +2577,19 @@ class MLIRGenImpl
 
                     if (callOpsCount <= paramIndex)
                     {
-                        // there is no more ops
+                        // there is no more ops; mark processed so the param is counted once -
+                        // recounting it every round inflated totalProcessed past the termination
+                        // equality below and spun the loop into the "loop detected" guard
                         if (paramInfo->getIsOptional() || isa<mlir_ts::OptionalType>(paramType))
                         {
+                            paramInfo->processed = true;
                             processed++;
                             continue;
                         }
 
                         if (paramInfo->getIsMultiArgsParam())
                         {
+                            paramInfo->processed = true;
                             processed++;
                             continue;
                         }
@@ -2640,8 +2644,11 @@ class MLIRGenImpl
 
                 if (processed == 0)
                 {
-                    emitError(location) << "not all types could be inferred";
-                    return mlir::failure();
+                    // no progress in a full round: some params (e.g. a callback typed by a
+                    // type param that only gets its value from a default) can't be inferred
+                    // here; the default zipping and the completeness check below decide
+                    // whether that is an error
+                    break;
                 }
 
                 totalProcessed += processed;
@@ -2653,7 +2660,7 @@ class MLIRGenImpl
 
                 if (totalProcessed > funcOp->getParams().size() + 100)
                 {
-                    // TODO: find out the issue
+                    // defensive only: with params counted exactly once this is unreachable
                     emitError(location) << "loop detected.";
                     return mlir::failure();
                 }


### PR DESCRIPTION
## Summary

Root-causes and fixes A3 from `docs/MLIRGen-refactoring-review.md` — the `// TODO: find out the issue` behind the arbitrary `+100` "loop detected." guard in `resolveGenericParamsFromFunctionCall`.

Two defects fed each other:

1. **Params without call operands were counted every round.** Optional/multi-args params past `callOpsCount` did `processed++` each iteration without being marked `processed`, so `totalProcessed` inflated by that count per round and could step right over the `==` termination check — spinning the loop into the +100 guard. They are now marked `processed` and counted exactly once.
2. **That double-counting was load-bearing.** For signatures like the test suite's `reduce2<T, V = T>(this: T[], func: (v: V, t: T) => V, initial?: V)`, the callback param can *never* resolve inside the loop — `V` only gets its value from the default zipping that runs *after* it — and only the inflated count let the loop terminate. With honest counting, a zero-progress round now `break`s out of the loop instead of erroring immediately, letting the default zipping and the existing completeness check (`typeParamsWithArgs.size() < typeParams.size()` → the same "not all types could be inferred" message) decide whether inference actually failed.

Net effect: each param is counted at most once, the loop terminates by equality or by no-progress, and the +100 guard is now defensive-only (documented as such). One deliberate semantic refinement: a program whose type params are fully resolved despite an unresolvable-in-loop param now proceeds (previously it errored) — that is the `reduce2` shape, which the old code only accepted by accident of the double-count.

## Test plan

- First run of the full suite caught exactly the load-bearing case (`01lambdas` failing in compile + JIT) and drove the two-part fix — the final design is validated against the real corpus, not just theory
- Final run: **683/683 ctest tests passed** (155 s)
- Generic-inference smoke (`apply2<T, R>(f, v, tag?)` → `42`) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)