### PR TITLE
Fix segfault in declaration-export type walker on unregistered types

### DIFF
--- a/tslang/lib/TypeScript/MLIRGenImpl.h
+++ b/tslang/lib/TypeScript/MLIRGenImpl.h
@@ -9842,7 +9842,11 @@ class MLIRGenImpl
         auto cont = mlir::TypeSwitch<mlir::Type, bool>(type)
             .Case<mlir_ts::InterfaceType>([&](auto ifaceType) {
                 auto interfaceInfo = getInterfaceInfoByFullName(ifaceType.getName().getValue());
-                assert(interfaceInfo);
+                if (!interfaceInfo)
+                {
+                    // not registered (e.g. forward/ambient reference), nothing to export
+                    return true;
+                }
 
                 for (auto& method : interfaceInfo->methods)
                 {
@@ -9858,7 +9862,11 @@ class MLIRGenImpl
             })
             .Case<mlir_ts::ClassType>([&](auto classType) {
                 auto classInfo = getClassInfoByFullName(classType.getName().getValue());
-                assert(classInfo);
+                if (!classInfo)
+                {
+                    // not registered (e.g. forward/ambient reference), nothing to export
+                    return true;
+                }
 
                 for (auto& method : classInfo->methods)
                 {
@@ -9903,20 +9911,33 @@ class MLIRGenImpl
         auto cont = mlir::TypeSwitch<mlir::Type, bool>(type)
             .Case<mlir_ts::InterfaceType>([&](auto ifaceType) {
                 auto interfaceInfo = getInterfaceInfoByFullName(ifaceType.getName().getValue());
-                assert(interfaceInfo);
+                if (!interfaceInfo)
+                {
+                    // not registered (e.g. forward/ambient reference), nothing to export
+                    return true;
+                }
+
                 addInterfaceDeclarationToExport(interfaceInfo);
                 return true;
             })
             .Case<mlir_ts::ClassType>([&](auto classType) {
                 auto classInfo = getClassInfoByFullName(classType.getName().getValue());
-                assert(classInfo);
+                if (!classInfo)
+                {
+                    // not registered (e.g. forward/ambient reference), nothing to export
+                    return true;
+                }
+
                 addClassDeclarationToExport(classInfo);
                 return true;
             })
             .Case<mlir_ts::EnumType>([&](auto enumType) {
                 auto enumInfo = getEnumInfoByFullName(enumType.getName().getValue());
-                assert(enumInfo);
-                assert(enumInfo->enumType == enumType);
+                if (!enumInfo || enumInfo->enumType != enumType)
+                {
+                    // not registered (e.g. forward/ambient reference), nothing to export
+                    return true;
+                }
 
                 addEnumDeclarationToExport(enumInfo->name, enumInfo->elementNamespace, enumType);
                 return true;
@@ -9926,7 +9947,7 @@ class MLIRGenImpl
             });
 
         return cont;
-    }    
+    }
 
     void addTypeDeclarationToExport(StringRef name, NamespaceInfo::TypePtr elementNamespace, mlir::Type type)    
     {


### PR DESCRIPTION
## Summary
- Fixes the segfault reported in #231: on Linux release builds (`NDEBUG`), the `--export=all` declaration-export walker in `MLIRGenImpl.h` dereferenced a null `ClassInfo`/`InterfaceInfo`/`EnumInfo` shared_ptr when a referenced type (e.g. one reachable only from a `declare function` signature in a `.d.ts` file) wasn't registered in the corresponding lookup map. The only guard was `assert(...)`, which is compiled out in release builds, so the lookup miss fell straight through to a null-pointer dereference — matching the reporter's gdb backtrace through `addClassDeclarationToExport`.
- Replaces the unguarded asserts in `addDependancyTypesToExportNoCheck` and `addTypeDeclarationToExportNoCheck` with graceful early-returns, matching the existing safe null-check pattern already used elsewhere (`MLIRTypeIterator.h`) for the same kind of lookup.

## Test plan
- [x] Compiled `MLIRGenClasses.cpp` and `MLIRGenModule.cpp` (both include the modified header) — no new warnings/errors.
- [ ] Reporter's original `BrowserLib` repro project would be a good end-to-end check once the default lib with `Uint8Array`/typed-array support is available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)