### PR TITLE
Fix llvm_unreachable aborts resolving unknown field/method names in getFieldTypeByFieldName

### DIFF
--- a/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
@@ -2322,12 +2322,13 @@ class MLIRTypeHelper
 
         if (auto srcClassType = dyn_cast<mlir_ts::ClassType>(srcType))
         {
-            if (auto srcClassInfo = getInterfaceInfoByFullName(srcClassType.getName().getValue()))
+            if (auto srcClassInfo = getClassInfoByFullName(srcClassType.getName().getValue()))
             {
-                auto fieldInfo = srcClassInfo->findField(fieldName);
-                if (fieldInfo)
+                auto foundField = false;
+                auto fieldInfo = srcClassInfo->findField(fieldName, foundField);
+                if (foundField)
                 {
-                    return fieldInfo->type;
+                    return fieldInfo.type;
                 }
 
                 if (auto strName = dyn_cast<mlir::StringAttr>(fieldName))

--- a/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
@@ -2372,8 +2372,9 @@ class MLIRTypeHelper
                 return mlir_ts::AnyType::get(context);
             }
 
-            llvm_unreachable("not implemented");
-        }        
+            // any other field (e.g. an extension method name like "push"/"pop") is not a data field of the array
+            return mlir::Type();
+        }
 
         // TODO: read fields info from class Array
         if (auto constArrayType = dyn_cast<mlir_ts::ConstArrayType>(srcType))

--- a/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
@@ -2314,10 +2314,6 @@ class MLIRTypeHelper
                     {
                         return methodInfo->funcType;
                     }
-                    else
-                    {
-                        llvm_unreachable("not implemented");
-                    }
                 }
             }
 
@@ -2340,10 +2336,6 @@ class MLIRTypeHelper
                     if (methodInfo)
                     {
                         return methodInfo->funcType;
-                    }
-                    else
-                    {
-                        llvm_unreachable("not implemented");
                     }
                 }
             }
@@ -2390,8 +2382,9 @@ class MLIRTypeHelper
                 return mlir_ts::AnyType::get(context);
             }
 
-            llvm_unreachable("not implemented");
-        }        
+            // any other field (e.g. an extension method name like "push"/"pop") is not a data field of the array
+            return mlir::Type();
+        }
 
         // TODO: read data from String class
         if (auto stringType = dyn_cast<mlir_ts::StringType>(srcType))
@@ -2401,8 +2394,9 @@ class MLIRTypeHelper
                 return mlir_ts::NumberType::get(context);
             }
 
-            llvm_unreachable("not implemented");
-        }        
+            // any other field (e.g. a method name like "fromCharCode"/"charAt") is not a data field of String
+            return mlir::Type();
+        }
 
         if (auto unionType = dyn_cast<mlir_ts::UnionType>(srcType))
         {


### PR DESCRIPTION
## Summary
- Follow-up to #237 for #231. After fixing the null-deref segfault in the `--export=all` declaration-export walker, reproducing the reporter's `BrowserLib` project against the real default lib (`TypeScriptCompilerDefaultLib`) surfaced further crashes in `MLIRTypeHelper::getFieldTypeByFieldName`, and while fixing those, a separate wrong-lookup bug in the same function.

### Crashes (commits 1-2)
- `Uint8Array`/`Int32Array` resolve through the default lib as `type Uint8Array = TypedArray<u8>`, a generic class built on `Array<T>`. `--export=all` forces eager full-body instantiation of referenced types, which walks every method of `Array<T>`/`TypedArray<T>` -- including ones like `push`/`pop`/`entries` that call through to `this.data.<method>()`, an extension-method call on the raw array type.
- `getFieldTypeByFieldName` had the same defect in five branches: it special-cased a couple of known field names, then called `llvm_unreachable("not implemented")` for anything else -- including legitimate method names -- instead of returning "not found" so the caller can keep looking (e.g. via extension functions). Fixed all five (`ArrayType`, `ConstArrayType`, `StringType`, `InterfaceType`, `ClassType`).
- This also matters for the `UnionType` branch in the same function, which calls `getFieldTypeByFieldName` per member and expects a falsy result for "member doesn't have this field" -- before this fix, a union containing an affected member type would abort the whole process instead of just excluding that member.

### Wrong lookup table (commit 3)
- While reviewing the `ClassType` branch, found it called `getInterfaceInfoByFullName()` with a *class's* full name instead of `getClassInfoByFullName()` -- looking up class field/method info in the wrong registry. Since classes and interfaces are registered in separate tables, this essentially never succeeded for a real class, silently returning "field not found" for every field/method access on a class type. This affects the `in` operator on class instances and `extendsType`'s structural matching of classes against tuple-shaped constraints (e.g. `T extends { length: number }`).
- `ClassInfo::findField`/`findMethod` have a different signature than `InterfaceInfo`'s (`findField` takes a `bool&` out-param and returns a value rather than a pointer), so the call site needed updating to match, not just the lookup function swap.

## Test plan
- [x] Rebuilt `tslang` (release) with all three commits.
- [x] Compiled the reporter's `native.d.ts` (from the issue's attached `BrowserLib.zip`) with `--export=all` against the real default lib -- previously aborted with `UNREACHABLE executed at .../MLIRTypeHelper.h:2375`, now compiles cleanly (exit 0).
- [x] Compiled all 16 `.ts`/`.d.ts` files from the reporter's `BrowserLib/runtime/object/Window` directory individually with `--export=all` -- no crashes on any file; remaining failures are ordinary unresolved-symbol errors from files needing sibling `import`s not present when compiled standalone (expected).
- [x] Ran the full `test/tester/tests` suite (365 `.ts` files) through the fixed compiler (parse + MLIR codegen): zero crashes, zero new failures vs. the pre-fix baseline binary (the 3 pre-existing failures fail identically on both, for unrelated reasons -- missing sibling files / pre-existing issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)