### PR TITLE
Use const for hand-written iterator objects in 00generator.ts

### DIFF
--- a/tslang/test/tester/tests/00generator.ts
+++ b/tslang/test/tester/tests/00generator.ts
@@ -22,8 +22,7 @@ function makeRangeIterator1(start: int, end: int, step: int) {
 }
 
 function main1() {
-    // DO NOT PUT CONST, otherwise you can't edit
-    let it = makeRangeIterator1(1, 10, 2);
+    const it = makeRangeIterator1(1, 10, 2);
 
     let count = 0;
     let result = it.next();
@@ -60,8 +59,7 @@ function makeRangeIterator2(start: int, end: int, step: int) {
 }
 
 function main2() {
-    // DO NOT PUT CONST, otherwise you can't edit
-    let it = makeRangeIterator2(1, 10, 2);
+    const it = makeRangeIterator2(1, 10, 2);
 
     let count = 0;
     let result = it.next();
@@ -98,8 +96,7 @@ function makeRangeIterator3(start = 0, end = 10000, step = 1) {
 }
 
 function main3() {
-    // DO NOT PUT CONST, otherwise you can't edit
-    let it = makeRangeIterator3(1, 10, 2);
+    const it = makeRangeIterator3(1, 10, 2);
 
     let count = 0;
     let result = it.next();


### PR DESCRIPTION
## Summary
- The `// DO NOT PUT CONST, otherwise you can't edit` comments in `00generator.ts` (main1/main2/main3) dated back to the bug fixed in #244: a `const` binding with no backing storage couldn't correctly mutate an object's state through a bound method (like `.next()` mutating `this.nextIndex`/`this.iterationCount`).
- That's fixed. Verified `const` bindings to these hand-written iterator objects now advance state correctly across manual `.next()` calls. Switched `let it` → `const it` in all three `main*` functions and removed the stale comments — `it` is never reassigned in any of them anyway.
- Scanned the rest of the test suite for similar stale "don't use const" style comments; this was the only file with this pattern.

## Test plan
- [x] `00generator.ts` (compile + JIT) passes with `const` iterator bindings
- [x] Full suite: 351/351 JIT + 355/355 compile, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)