### PR TITLE
Fix cross-module interface field/method vtable index mismatch

### DIFF
--- a/tslang/include/TypeScript/MLIRLogic/MLIRGenStore.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRGenStore.h
@@ -539,6 +539,38 @@ struct InterfaceInfo
         return offset + methods.size() + fields.size();
     }
 
+    // vtable slot numbers must be a pure function of the interface's own declaration
+    // (extends, then own methods in order, then own fields in order) - NOT of whichever
+    // object happens to be cast to it first. getVirtualTable() re-derives the same
+    // methods-then-fields order per-cast (needed to mark per-object optional members
+    // missing), but a module that only reads an already-typed interface value - without
+    // ever casting an object to it itself (e.g. importing an already-boxed global from
+    // another compilation unit) - never runs getVirtualTable() at all. Without this
+    // eagerly-computed, cast-independent pass, such a module falls back on the
+    // interleaved declaration-order index assigned at member-registration time
+    // (mlirGenInterfaceAddFieldMember / addInterfaceMethod), which disagrees with the
+    // methods-first layout whenever a field is declared before a method in source order -
+    // reading through the wrong vtable slot (e.g. a method's function pointer
+    // reinterpreted as a field offset) and crashing.
+    void assignCanonicalVirtualIndexes()
+    {
+        auto offset = 0;
+        for (auto &extent : extends)
+        {
+            offset += std::get<1>(extent)->getVTableSize();
+        }
+
+        for (auto &method : methods)
+        {
+            method.virtualIndex = offset++;
+        }
+
+        for (auto &field : fields)
+        {
+            field.virtualIndex = offset++;
+        }
+    }
+
     void recalcOffsets()
     {
         auto offset = 0;

--- a/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
+++ b/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
@@ -581,6 +581,11 @@ namespace mlirgen
 
         } while (notResolved > 0);
 
+        // fix up vtable slot numbers to the canonical methods-then-fields order now that
+        // all members are known - see assignCanonicalVirtualIndexes() for why this can't
+        // be left to getVirtualTable()'s per-cast assignment alone.
+        newInterfacePtr->assignCanonicalVirtualIndexes();
+
         // add to export if any
         if (auto hasExport = getExportModifier(interfaceDeclarationAST))
         {

--- a/tslang/test/tester/tests/export_object_literal_with_interface.ts
+++ b/tslang/test/tester/tests/export_object_literal_with_interface.ts
@@ -14,4 +14,11 @@ namespace A {
 
     // invalid Point3d is not exported
     export var Origin3d: Point3d = { x: 0, y: 0, z: 0 };
+
+    export interface Counter {
+        count: number;
+        inc(): void;
+    }
+
+    export var counter: Counter = { count: 0, inc() { this.count = this.count + 1; } };
 }

--- a/tslang/test/tester/tests/import_object_literal_with_interface.ts
+++ b/tslang/test/tester/tests/import_object_literal_with_interface.ts
@@ -10,4 +10,6 @@ if (A.Origin3d.x == 0)
 	print("ok");
 }
 
+print(A.counter.count);
+
 print("done.");


### PR DESCRIPTION
## Summary
- Interface vtable slot numbers (`InterfaceInfo::fields`/`methods`'s `virtualIndex`) were assigned by two inconsistent algorithms: declaration-time assignment used raw interleaved declaration order, while cast-time assignment (`getVirtualTable`) always puts all methods before all fields.
- A module that only reads an already-typed interface value it imported (e.g. `A.counter.count` where `A.counter` is `export`ed from another compiled module) never triggers the cast-time algorithm, so it kept the stale declaration-order index while the exporting module's real vtable used the methods-first layout - a field read could land on a method's vtable slot (a function pointer misread as a `thisVal`-relative byte offset) and crash the JIT with `0xC0000005`.
- Fix: `InterfaceInfo::assignCanonicalVirtualIndexes()` computes the canonical (extends-offset, then methods in order, then fields in order) layout once when an interface declaration finishes resolving, independent of any cast - so every module that parses/re-parses the same interface declaration (including the `@dllimport` textual redeclaration path used for `-shared` imports) agrees on slot numbers.
- Re-enabled the `Counter` interface field/method regression coverage in `export_object_literal_with_interface.ts` / `import_object_literal_with_interface.ts` that was previously reverted (crashing) while this bug was still open.

## Test plan
- [x] `ctest -R export-import-object-literal-with-interface` (both AOT and JIT variants) now pass
- [x] Full suite: `ctest -C Debug` - 714/714 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)