### PR TITLE
Fix generic constraint matching for method-shaped receivers

### DIFF
--- a/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRTypeHelper.h
@@ -2333,7 +2333,27 @@ class MLIRTypeHelper
             }
 
             return tupleType.getFieldInfo(index).type;
-        }  
+        }
+
+        if (auto objectStorageType = dyn_cast<mlir_ts::ObjectStorageType>(srcType))
+        {
+            auto index = objectStorageType.getIndex(fieldName);
+            if (index < 0)
+            {
+                return mlir::Type();
+            }
+
+            return objectStorageType.getFieldInfo(index).type;
+        }
+
+        // a generator/boxed-object return type (e.g. `function*`'s BoxAsObject
+        // wrapper) is not itself a tuple - unwrap to its underlying storage type
+        // (TupleType/ConstTupleType/ObjectStorageType) so structural constraint
+        // matching (e.g. `TIter extends { next(): ... }`) can see its fields.
+        if (auto objectType = dyn_cast<mlir_ts::ObjectType>(srcType))
+        {
+            return getFieldTypeByFieldName(objectType.getStorageType(), fieldName);
+        }
 
         if (auto srcInterfaceType = dyn_cast<mlir_ts::InterfaceType>(srcType))
         {
@@ -2489,9 +2509,22 @@ class MLIRTypeHelper
             auto extIsVarArgs = getVarArgFromFuncRef(extendType);
 
             auto srcReturnType = getReturnTypeFromFuncRef(srcType);
-            auto extReturnType = getReturnTypeFromFuncRef(extendType);       
+            auto extReturnType = getReturnTypeFromFuncRef(extendType);
 
-            return extendsTypeFuncTypes(location, srcParams, extParams, extIsVarArgs, srcReturnType, extReturnType, typeParamsWithArgs, skipSrcParams);    
+            // when srcType's leading (bound `this`) param is being skipped, the
+            // constraint's own leading `this` placeholder (an OpaqueType standing
+            // in for "any this type", e.g. a method-shaped generic constraint like
+            // `{ next(): ... }`) must be skipped in lockstep - otherwise the two
+            // param lists go out of alignment by one and every real param after it
+            // is compared against the wrong slot (or a null past the end).
+            auto skipExtParams = skipSrcParams > 0 && !extParams.empty() && mlir::isa<mlir_ts::OpaqueType>(extParams.front())
+                ? 1 : 0;
+            if (skipExtParams)
+            {
+                extParams = extParams.drop_front(skipExtParams);
+            }
+
+            return extendsTypeFuncTypes(location, srcParams, extParams, extIsVarArgs, srcReturnType, extReturnType, typeParamsWithArgs, skipSrcParams);
     }
 
     ExtendsResult extendsTypeFuncTypes(mlir::Location location, ArrayRef<mlir::Type> srcParams, ArrayRef<mlir::Type> extParams, bool extIsVarArgs, 


### PR DESCRIPTION
## Summary
- `extendsTypeFuncTypes` skipped the receiver's bound `this` param when comparing against a method-shaped generic constraint (e.g. `TIter extends { next(): {...} }`), but never skipped the constraint's own leading `this` placeholder (`OpaqueType`) in lockstep — misaligning the two parameter lists by one and causing every subsequent parameter comparison to fail (collapsing to `<<NULL TYPE>>` vs `!ts.opaque`).
- This blocked any extension method whose generic constraint requires a method-shaped field on the receiver — concretely, TypeScriptCompilerDefaultLib's `__Iterator.take/drop/every/filter/find/forEach/map/reduce/some/toArray` never resolved on generator (`function*`) return types (`fibonacci().take(5)`, `fibonacci().every(fn)`, etc. all failed to compile).
- Also added `ObjectType`/`ObjectStorageType` cases to `getFieldTypeByFieldName` so a boxed generator return type exposes its fields (e.g. `next()`) to structural constraint checks in the first place.

Root-caused via LLVM debug tracing (`-debug-only=mlir`) on a Debug JIT build, isolating the exact `extendsType` recursion where the receiver's `next()` method type was compared against the constraint's `next()` signature and one side's parameter came back null.

## Test plan
- [x] Rebuilt `tslang` (Debug + Release) with the fix
- [x] Ran TypeScriptCompilerDefaultLib's full `tests.ps1` suite (release/debug × compile/jit, 150 tests × 4 = 600 runs): **150/150 passing on all four**, including the 10 previously-failing `iterator_*.ts` tests (`iterator_drop/every/filter/find/forEach/map/reduce/some/take/toArray`)
- [x] No regressions in the other 140 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)