### PR TITLE
Fix cross-module generic interface export and add coverage

### DIFF
--- a/tslang/lib/TypeScript/MLIRGenImpl.h
+++ b/tslang/lib/TypeScript/MLIRGenImpl.h
@@ -10367,6 +10367,47 @@ class MLIRGenImpl
         genericDeclExports << ss.str().str();
     }
 
+    void addGenericInterfaceDeclarationToExport(GenericInterfaceInfo::TypePtr genericInterfaceInfo)
+    {
+        if (genericInterfaceInfo->interfaceType && isAddedToExport(genericInterfaceInfo->interfaceType))
+        {
+            // already added
+            return;
+        }
+
+        // same bounds-check as addGenericClassDeclarationToExport - a generic interface
+        // re-declared while re-importing another module's embedded declarations still
+        // carries its own `export` keyword verbatim, but at that point `sourceFile` is
+        // the ambient/outer file, not the "partial" buffer parsePartialStatements
+        // actually parsed this declaration from.
+        auto declEnd = static_cast<size_t>(genericInterfaceInfo->interfaceDeclaration->_end);
+        if (declEnd > genericInterfaceInfo->sourceFile->text.length())
+        {
+            return;
+        }
+
+        if (genericInterfaceInfo->interfaceType)
+        {
+            exportedTypes.insert(genericInterfaceInfo->interfaceType);
+        }
+
+        // like a generic class, a generic interface has no compiled body for any given
+        // instantiation: each importing module instantiates it locally, on demand,
+        // exactly like a same-file usage would. So the FULL original source - type
+        // parameters and member signatures intact, no @dllimport marker - must be
+        // re-exported verbatim for parsePartialStatements to recompile per instantiation
+        // in the importer.
+        auto declText = convertWideToUTF8(getTextOfNodeFromSourceText(
+            genericInterfaceInfo->sourceFile->text, genericInterfaceInfo->interfaceDeclaration.as<Node>(), true));
+
+        SmallVector<char> out;
+        llvm::raw_svector_ostream ss(out);
+        MLIRDeclarationPrinter dp(ss);
+        dp.printGenericClass(genericInterfaceInfo->elementNamespace, declText);
+
+        genericDeclExports << ss.str().str();
+    }
+
     auto getNamespaceName() -> StringRef
     {
         return currentNamespace->name;

--- a/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
+++ b/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
@@ -505,6 +505,17 @@ namespace mlirgen
             auto fullNamePtr = getFullNamespaceName(namePtr);
             if (fullNameGenericInterfacesMap.count(fullNamePtr))
             {
+                // already registered - but the registration itself typically happens during
+                // Stages::Discovering (before addGenericInterfaceDeclarationToExport's
+                // isAddedToExport gate, which only actually emits once stage ==
+                // Stages::SourceGeneration, will do anything) - retry the export step alone
+                // using the existing GenericInterfaceInfo rather than skipping it entirely.
+                // Mirrors registerGenericClass's identical gotcha-3 fix.
+                if (getExportModifier(interfaceDeclarationAST))
+                {
+                    addGenericInterfaceDeclarationToExport(fullNameGenericInterfacesMap.lookup(fullNamePtr));
+                }
+
                 return mlir::success();
             }
 
@@ -528,6 +539,18 @@ namespace mlirgen
 
             getGenericInterfacesMap().insert({namePtr, newGenericInterfacePtr});
             fullNameGenericInterfacesMap.insert(fullNamePtr, newGenericInterfacePtr);
+
+            // support dynamic loading: a generic interface is never instantiated in this
+            // module if nothing here uses it concretely, so mlirGen(InterfaceDeclaration)'s
+            // own addInterfaceDeclarationToExport call never runs for the bare template (it
+            // only fires for a SPECIALIZED instantiation) - the bare template needs to be
+            // exported here instead, the one place every generic interface declaration
+            // passes through regardless of whether it is ever instantiated locally. Mirrors
+            // registerGenericClass.
+            if (getExportModifier(interfaceDeclarationAST))
+            {
+                addGenericInterfaceDeclarationToExport(newGenericInterfacePtr);
+            }
 
             return mlir::success();
         }

--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -884,6 +884,7 @@ add_test(NAME test-compile-export-import-class-static COMMAND test-runner "${PRO
 #     declaration's own re-export attempt hit a stale source-file/AST-position mismatch).
 # See class-generic-declaration-export-fix memory for the full account.
 add_test(NAME test-compile-export-import-class-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
+add_test(NAME test-compile-export-import-interface-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 add_test(NAME test-compile-export-import-class-accessor COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")
 add_test(NAME test-compile-export-import-class-indexer COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_indexer.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_indexer.ts")
 add_test(NAME test-compile-export-import-interface-indexer COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_indexer.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_indexer.ts")
@@ -955,6 +956,7 @@ add_test(NAME test-compile-shared-export-import-class-structural-interface COMMA
 # add_test(NAME test-compile-shared-export-import-class-implements-interface-abstract COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_implements_interface_abstract.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_implements_interface_abstract.ts")
 # FIXED: see the matching test-compile-export-import-class-generic comment above (2026-07-22).
 add_test(NAME test-compile-shared-export-import-class-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
+add_test(NAME test-compile-shared-export-import-interface-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED (2026-07-22): the -shared declaration-reconstruction path never printed real
 # get/set syntax for a class's accessors, only the underlying get_x/set_x funcOps as
 # ordinary methods - so property-style access ("Class member 'celsius' can't be found")
@@ -1001,6 +1003,7 @@ add_test(NAME test-jit-shared-export-import-class-structural-interface COMMAND t
 # add_test(NAME test-jit-shared-export-import-class-implements-interface-abstract COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_implements_interface_abstract.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_implements_interface_abstract.ts")
 # FIXED: see the matching test-compile-export-import-class-generic comment above (2026-07-22).
 add_test(NAME test-jit-shared-export-import-class-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
+add_test(NAME test-jit-shared-export-import-interface-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED: see the matching test-compile-shared-export-import-class-accessor comment above (2026-07-22).
 add_test(NAME test-jit-shared-export-import-class-accessor COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")
 add_test(NAME test-jit-shared-export-import-class-indexer COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_indexer.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_indexer.ts")

--- a/tslang/test/tester/tests/export_interface_generic.ts
+++ b/tslang/test/tester/tests/export_interface_generic.ts
@@ -1,0 +1,20 @@
+namespace M {
+
+    // Cross-module counterpart to 00interface_generic.ts. GenericInterfaceInfo
+    // (MLIRGenStore.h) is structurally analogous to GenericClassInfo/
+    // GenericFunctionInfo, both of whose cross-module export gaps needed
+    // dedicated fixes (PR #280, PR #285) - flagged as a plausible, unverified
+    // instance of the same "never routed into declExports" gap in
+    // decls-cross-module-declaration-mechanism / generic-function-cross-module-export-fix.
+
+    export interface Box<T> {
+        value: T;
+        get(): T;
+    }
+
+    export interface Pair<A, B> {
+        first: A;
+        second: B;
+        describe(): string;
+    }
+}

--- a/tslang/test/tester/tests/import_interface_generic.ts
+++ b/tslang/test/tester/tests/import_interface_generic.ts
@@ -1,0 +1,38 @@
+import './export_interface_generic'
+
+class NumberBox implements M.Box<number> {
+    value: number;
+
+    constructor(v: number) {
+        this.value = v;
+    }
+
+    get(): number {
+        return this.value;
+    }
+}
+
+class NumberStringPair implements M.Pair<number, string> {
+    first: number;
+    second: string;
+
+    constructor(a: number, b: string) {
+        this.first = a;
+        this.second = b;
+    }
+
+    describe(): string {
+        return `${this.second}-${this.first}`;
+    }
+}
+
+function main() {
+    const b: M.Box<number> = new NumberBox(42);
+    assert(b.get() == 42);
+    assert(b.value == 42);
+
+    const p: M.Pair<number, string> = new NumberStringPair(1, "one");
+    assert(p.describe() == "one-1");
+
+    print("done.");
+}


### PR DESCRIPTION
## Summary
- [decls-cross-module-declaration-mechanism](https://github.com/ASDAlexander77/TypeScriptCompiler/pull/280) / [generic-function-cross-module-export-fix](https://github.com/ASDAlexander77/TypeScriptCompiler/pull/285) flagged `GenericInterfaceInfo` as structurally analogous to `GenericClassInfo`/`GenericFunctionInfo`, and a plausible, unverified instance of the same "never routed into `declExports`" gap (#280, #285). Confirmed for interfaces: `-shared` cross-module use of a generic interface failed name resolution entirely (`can't resolve name: M`).
- Added `addGenericInterfaceDeclarationToExport`, mirroring `addGenericClassDeclarationToExport`/`addGenericFunctionDeclarationToExport`: re-prints the bare generic interface's full original source (type params and member signatures intact, no `@dllimport` marker) into the `__decls_generic_*` embedded declaration global. Wired into `registerGenericInterface` at both the initial-registration site and the "already registered" early-return path (needed because registration happens during `Stages::Discovering`, before `isAddedToExport`'s stage gate does anything).
- **Unlike the class/function cases, no export-bleed suppression was needed.** `mlirGen(InterfaceDeclaration)` does call `addInterfaceDeclarationToExport` for a concrete instantiation (reusing the same AST node's export modifier - same shape of bug that hit classes/functions), but interfaces don't carry a linker-visible dllexport symbol the way a class/function's compiled body does. Confirmed via `dumpbin /directives` on the built object: no `/EXPORT:` entry for either a single- or multi-type-param interface instantiation (`Box<number>`, `Pair<number,string>`), only the harmless `__decls_generic_*` marker. No lld crash, so no fix needed for that half.

## Test plan
- [x] New `export_interface_generic.ts` / `import_interface_generic.ts` cross-module pair (single- and two-type-param generic interfaces, used via `implements` and as a variable type annotation), 3 tiers: `test-compile-export-import-interface-generic`, `test-compile-shared-export-import-interface-generic`, `test-jit-shared-export-import-interface-generic`
- [x] Full suite: `ctest -C Debug -j8` — 802/802 green (799 previously green + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)