### PR TITLE
Remove stale disabled-test comments and re-enable already-fixed tests

### DIFF
--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -327,8 +327,7 @@ add_test(NAME test-compile-01-optional COMMAND test-runner "${PROJECT_SOURCE_DIR
 add_test(NAME test-compile-00-async-await COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00async_await.ts")
 add_test(NAME test-compile-00-for-await COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00for_await.ts")
 
-# TODO: in opt mode, error
-#add_test(NAME test-compile-00-for-await-yield COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00for_await_yield.ts")
+add_test(NAME test-compile-00-for-await-yield COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00for_await_yield.ts")
 add_test(NAME test-compile-00-types COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00types.ts")
 add_test(NAME test-compile-00-try-catch COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00try_catch.ts")
 add_test(NAME test-compile-01-try-catch COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/01try_catch.ts")
@@ -435,7 +434,6 @@ add_test(NAME test-compile-244-arraysome COMMAND test-runner "${PROJECT_SOURCE_D
 add_test(NAME test-compile-Grammar_and_types COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/Grammar_and_types.ts")
 add_test(NAME test-compile-StackTest COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00stack_test.ts")
 if (WIN32)
-# TODO: find out why it is crashing
 add_test(NAME test-compile-Raytrace COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/raytrace.ts")
 endif()
 add_test(NAME test-compile-Path COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/path.ts")
@@ -691,8 +689,6 @@ add_test(NAME test-jit-00-optional COMMAND test-runner -jit "${PROJECT_SOURCE_DI
 add_test(NAME test-jit-01-optional COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/01optional.ts")
 add_test(NAME test-jit-00-async-await COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00async_await.ts")
 add_test(NAME test-jit-00-for-await COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00for_await.ts")
-# TODO: async generator / for-await-of hangs at runtime under JIT
-# error: EXEC : LLVM error : Coroutines cannot handle non static allocas yet
 add_test(NAME test-jit-00-for-await-yield COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00for_await_yield.ts")
 add_test(NAME test-jit-00-try-catch COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00try_catch.ts")
 add_test(NAME test-jit-01-try-catch COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/01try_catch.ts")
@@ -805,7 +801,6 @@ add_test(NAME test-jit-243-arrayevery COMMAND test-runner  -jit "${PROJECT_SOURC
 add_test(NAME test-jit-244-arraysome COMMAND test-runner  -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/244arraysome.ts")
 add_test(NAME test-jit-Grammar_and_types COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/Grammar_and_types.ts")
 add_test(NAME test-jit-StackTest COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00stack_test.ts")
-# TODO: find out why it is crashing
 add_test(NAME test-jit-Raytrace COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/raytrace.ts")
 add_test(NAME test-jit-Path COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/path.ts")
 add_test(NAME test-jit-Print-Bug-01 COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/01print-bug.ts")


### PR DESCRIPTION
## Summary
- `test-compile-Raytrace` / `test-jit-Raytrace`: drop stale "TODO: find out why it is crashing" comments — fixed 2026-07-05 (JIT'd globals weren't registered as Boehm GC roots).
- `test-compile-00-for-await-yield`: re-enable (was fully commented out) — fixed the same day (dynamic stack alloca inside a presplit coroutine forced to heap allocation instead).
- `test-jit-00-for-await-yield`: drop a stale comment describing the same now-fixed crash above an already-enabled, already-passing test.

No production code changes — comment/registration cleanup only, found while reviewing test coverage after #290.

## Test plan
- [x] `ctest -C Debug -j 8`: 817/817 passed (816 + newly re-enabled test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)