### PR TITLE
Add plain cross-module test coverage for functions and type aliases

### DIFF
--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -885,6 +885,13 @@ add_test(NAME test-compile-export-import-class-static COMMAND test-runner "${PRO
 add_test(NAME test-compile-export-import-class-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-compile-export-import-function-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-compile-export-import-type-alias-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+# plain (non-generic) counterparts - every other declaration kind (class, interface, enum, vars)
+# already had both a "-generic" and a plain cross-module export/import pair; function and
+# type-alias only had "-generic". Confirmed working (not a gap) before adding: default/optional
+# params, union/chained-alias/object-shape aliases, and an aliased type used in a function
+# signature all round-trip correctly through __decls across all 3 tiers.
+add_test(NAME test-compile-export-import-function COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-compile-export-import-type-alias COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-compile-export-import-interface-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 add_test(NAME test-compile-export-import-class-accessor COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")
 add_test(NAME test-compile-export-import-class-indexer COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_indexer.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_indexer.ts")
@@ -961,6 +968,8 @@ add_test(NAME test-compile-shared-export-import-class-abstract-virtual-dispatch 
 add_test(NAME test-compile-shared-export-import-class-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-compile-shared-export-import-function-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-compile-shared-export-import-type-alias-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+add_test(NAME test-compile-shared-export-import-function COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-compile-shared-export-import-type-alias COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-compile-shared-export-import-interface-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED (2026-07-22): the -shared declaration-reconstruction path never printed real
 # get/set syntax for a class's accessors, only the underlying get_x/set_x funcOps as
@@ -1011,6 +1020,8 @@ add_test(NAME test-jit-shared-export-import-class-abstract-virtual-dispatch COMM
 add_test(NAME test-jit-shared-export-import-class-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-jit-shared-export-import-function-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-jit-shared-export-import-type-alias-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+add_test(NAME test-jit-shared-export-import-function COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-jit-shared-export-import-type-alias COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-jit-shared-export-import-interface-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED: see the matching test-compile-shared-export-import-class-accessor comment above (2026-07-22).
 add_test(NAME test-jit-shared-export-import-class-accessor COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")

--- a/tslang/test/tester/tests/export_function.ts
+++ b/tslang/test/tester/tests/export_function.ts
@@ -1,0 +1,34 @@
+namespace M {
+
+    // Cross-module counterpart to 01arguments.ts / 00funcs.ts, but for a plain
+    // (non-generic) function - every other declaration kind (class, interface,
+    // enum, vars) has both a "-generic" and a plain cross-module export/import
+    // test pair; function only had "-generic" (import_function_generic.ts).
+    // Covers what DeclarationPrinter's printFunction/printParams must round-trip
+    // correctly through __decls: a required param, an optional param (`?`), a
+    // default-valued param, and a void return.
+
+    export function add(a: number, b: number): number {
+        return a + b;
+    }
+
+    export function greet(name: string, greeting: string = "Hello"): string {
+        return `${greeting}, ${name}!`;
+    }
+
+    export function maybeDouble(x: number, factor?: number): number {
+        if (factor == undefined) factor = 2;
+        return x * factor;
+    }
+
+    export function noop(): void {
+    }
+
+    // a function in the exporting module calling ANOTHER function declared in
+    // the SAME exporting module - exercises that intra-module calls still
+    // resolve correctly once this module is compiled as a dynamic-import target
+    // rather than compiled standalone (distinct from the importer calling in).
+    export function addTwice(a: number, b: number): number {
+        return add(a, b) + add(a, b);
+    }
+}

--- a/tslang/test/tester/tests/export_type_alias.ts
+++ b/tslang/test/tester/tests/export_type_alias.ts
@@ -1,0 +1,25 @@
+namespace M {
+
+    // Cross-module counterpart to decl_type.ts, but broader - every other
+    // declaration kind has both a "-generic" and a plain cross-module test
+    // pair; type alias only had "-generic" (import_type_alias_generic.ts).
+    // Covers a primitive alias, an object-shape alias, a union alias, an
+    // alias-of-alias chain, and a function whose signature uses one of these
+    // aliases (so the printed __decls text must resolve the alias by name,
+    // not just inline its expansion).
+
+    export type Id = number;
+
+    export type UserId = Id;
+
+    export type Point = {
+        x: number;
+        y: number;
+    };
+
+    export type Status = number | string;
+
+    export function makePoint(x: number, y: number): Point {
+        return { x: x, y: y };
+    }
+}

--- a/tslang/test/tester/tests/import_function.ts
+++ b/tslang/test/tester/tests/import_function.ts
@@ -1,0 +1,17 @@
+import './export_function'
+
+function main() {
+    assert(M.add(2, 3) == 5);
+
+    assert(M.greet("World") == "Hello, World!");
+    assert(M.greet("World", "Hi") == "Hi, World!");
+
+    assert(M.maybeDouble(5) == 10);
+    assert(M.maybeDouble(5, 3) == 15);
+
+    M.noop();
+
+    assert(M.addTwice(2, 3) == 10);
+
+    print("done.");
+}

--- a/tslang/test/tester/tests/import_type_alias.ts
+++ b/tslang/test/tester/tests/import_type_alias.ts
@@ -1,0 +1,20 @@
+import './export_type_alias'
+
+function main() {
+    const id: M.Id = 42;
+    assert(id == 42);
+
+    const uid: M.UserId = 7;
+    assert(uid == 7);
+
+    const p: M.Point = M.makePoint(1, 2);
+    assert(p.x == 1);
+    assert(p.y == 2);
+
+    let s: M.Status = 5;
+    assert(s == 5);
+    s = "error";
+    assert(s == "error");
+
+    print("done.");
+}


### PR DESCRIPTION
## Summary

Every other declaration kind (class, interface, enum, vars) has both a `-generic` and a plain cross-module export/import test pair — function and type alias only had `-generic` (`import_function_generic.ts`, `import_type_alias_generic.ts`). Given the abstract-modifier bug fixed in #290 was exactly this shape (a declaration-printer round-trip gap that only end-to-end cross-module tests would catch), I tested the plausible-looking hypothesis that default/optional function parameters might not survive the `__decls` round-trip the same way.

**Confirmed working correctly, not a bug** — default params, optional params, and multiple type-alias shapes (primitive, object, union, chained alias-of-alias, and an alias used in a function signature) all round-trip correctly across the module boundary. Adding as permanent regression coverage rather than leaving it unverified:

- `export_function.ts` / `import_function.ts`: required + optional + default params, void return, and an intra-exporting-module function-to-function call (`addTwice` calling `add`).
- `export_type_alias.ts` / `import_type_alias.ts`: primitive alias, alias-of-alias, object-shape alias, union alias, and a function whose signature uses one of the aliases.

Registered across all 3 tiers (plain non-shared, `-shared` compile, `-shared` JIT) matching every other declaration kind's coverage pattern — 6 new `add_test` entries.

## Test plan

- [x] Manually verified all 3 tiers pass for both new pairs before registering them
- [x] Full `ctest -C Debug -j 8`: 823/823 passed (817 + these 6 new entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)