### PR TITLE
Add dedicated test coverage for root-level code with no function main()

### DIFF
--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -425,6 +425,13 @@ add_test(NAME test-compile-41-anonymoustypes COMMAND test-runner "${PROJECT_SOUR
 add_test(NAME test-compile-42-lambdaproperties COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/42lambdaproperties.ts")
 add_test(NAME test-compile-43-nestednamespace COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/43nestednamespace.ts")
 add_test(NAME test-compile-44-toplevelcode COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/44toplevelcode.ts")
+# 44toplevelcode.ts has top-level declarations but wraps its actual test logic in an
+# explicit main() - these two exercise executable statements running directly at root
+# scope with NO main() anywhere (generateGlobalEntryCode compiles the root statements
+# AS the synthesized `main` itself): control flow (for/while/switch/try-catch-finally)
+# plus a closure capturing a root-level `let` (module-scope storage, not a stack local).
+add_test(NAME test-compile-00-toplevel-control-flow COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00toplevel_control_flow.ts")
+add_test(NAME test-compile-00-toplevel-no-main-with-helpers COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00toplevel_no_main_with_helpers.ts")
 add_test(NAME test-compile-45-enumtostring COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/45enumtostring.ts")
 add_test(NAME test-compile-48-instanceof COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/48instanceof.ts")
 add_test(NAME test-compile-51-exceptions COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/51exceptions.ts")
@@ -793,6 +800,8 @@ add_test(NAME test-jit-41-anonymoustypes COMMAND test-runner -jit "${PROJECT_SOU
 add_test(NAME test-jit-42-lambdaproperties COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/42lambdaproperties.ts")
 add_test(NAME test-jit-43-nestednamespace COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/43nestednamespace.ts")
 add_test(NAME test-jit-44-toplevelcode COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/44toplevelcode.ts")
+add_test(NAME test-jit-00-toplevel-control-flow COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00toplevel_control_flow.ts")
+add_test(NAME test-jit-00-toplevel-no-main-with-helpers COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00toplevel_no_main_with_helpers.ts")
 add_test(NAME test-jit-45-enumtostring COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/45enumtostring.ts")
 add_test(NAME test-jit-48-instanceof COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/48instanceof.ts")
 add_test(NAME test-jit-51-exceptions COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/51exceptions.ts")

--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -885,6 +885,13 @@ add_test(NAME test-compile-export-import-class-static COMMAND test-runner "${PRO
 add_test(NAME test-compile-export-import-class-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-compile-export-import-function-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-compile-export-import-type-alias-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+# plain (non-generic) counterparts - every other declaration kind (class, interface, enum, vars)
+# already had both a "-generic" and a plain cross-module export/import pair; function and
+# type-alias only had "-generic". Confirmed working (not a gap) before adding: default/optional
+# params, union/chained-alias/object-shape aliases, and an aliased type used in a function
+# signature all round-trip correctly through __decls across all 3 tiers.
+add_test(NAME test-compile-export-import-function COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-compile-export-import-type-alias COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-compile-export-import-interface-generic COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 add_test(NAME test-compile-export-import-class-accessor COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")
 add_test(NAME test-compile-export-import-class-indexer COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_indexer.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_indexer.ts")
@@ -961,6 +968,8 @@ add_test(NAME test-compile-shared-export-import-class-abstract-virtual-dispatch 
 add_test(NAME test-compile-shared-export-import-class-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-compile-shared-export-import-function-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-compile-shared-export-import-type-alias-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+add_test(NAME test-compile-shared-export-import-function COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-compile-shared-export-import-type-alias COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-compile-shared-export-import-interface-generic COMMAND test-runner -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED (2026-07-22): the -shared declaration-reconstruction path never printed real
 # get/set syntax for a class's accessors, only the underlying get_x/set_x funcOps as
@@ -1011,6 +1020,8 @@ add_test(NAME test-jit-shared-export-import-class-abstract-virtual-dispatch COMM
 add_test(NAME test-jit-shared-export-import-class-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_generic.ts")
 add_test(NAME test-jit-shared-export-import-function-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function_generic.ts")
 add_test(NAME test-jit-shared-export-import-type-alias-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias_generic.ts")
+add_test(NAME test-jit-shared-export-import-function COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_function.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_function.ts")
+add_test(NAME test-jit-shared-export-import-type-alias COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_type_alias.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_type_alias.ts")
 add_test(NAME test-jit-shared-export-import-interface-generic COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_interface_generic.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_interface_generic.ts")
 # FIXED: see the matching test-compile-shared-export-import-class-accessor comment above (2026-07-22).
 add_test(NAME test-jit-shared-export-import-class-accessor COMMAND test-runner -jit -shared "${PROJECT_SOURCE_DIR}/test/tester/tests/import_class_accessor.ts" "${PROJECT_SOURCE_DIR}/test/tester/tests/export_class_accessor.ts")

--- a/tslang/test/tester/tests/00toplevel_control_flow.ts
+++ b/tslang/test/tester/tests/00toplevel_control_flow.ts
@@ -1,0 +1,71 @@
+// Root-level executable code with NO `function main()` anywhere in the file.
+// When there's no explicit `main`, generateGlobalEntryCode (MLIRGenModule.cpp)
+// gathers every statement that isn't inside a function/class body and compiles
+// it AS the synthesized `main` function itself - so this exercises the same
+// control-flow/closure/exception codegen every other test exercises inside an
+// explicit main(), just routed through the auto-synthesis path instead.
+// Also: a `let`/`const` declared directly at this level is module-scope
+// storage (like a static field), not a stack local - so the closure test
+// below captures a GLOBAL, not a stack frame slot.
+
+let sum = 0;
+for (let i = 0; i < 5; i++) {
+    if (i == 2) continue;
+    if (i == 4) break;
+    sum = sum + i;
+}
+assert(sum == 4, "for-if-continue-break");
+
+let count = 0;
+while (count < 3) {
+    count = count + 1;
+}
+assert(count == 3, "while");
+
+let label = "";
+switch (count) {
+    case 1:
+        label = "one";
+        break;
+    case 3:
+        label = "three";
+        break;
+    default:
+        label = "other";
+        break;
+}
+assert(label == "three", "switch");
+
+let caught = false;
+try {
+    throw 42.0;
+} catch (v: number) {
+    caught = v == 42;
+} finally {
+    sum = sum + 100;
+}
+assert(caught, "try-catch");
+assert(sum == 104, "finally-ran");
+
+let counter = 0;
+const increment = () => {
+    counter = counter + 1;
+};
+increment();
+increment();
+assert(counter == 2, "closure-capture-root-let");
+
+class Counter {
+    value: number = 0;
+    increment(): void {
+        this.value = this.value + 1;
+    }
+}
+
+const c = new Counter();
+c.increment();
+c.increment();
+c.increment();
+assert(c.value == 3, "class-at-root");
+
+print("done.");

--- a/tslang/test/tester/tests/00toplevel_no_main_with_helpers.ts
+++ b/tslang/test/tester/tests/00toplevel_no_main_with_helpers.ts
@@ -1,0 +1,31 @@
+// Root-level executable code coexisting with ordinary function/class
+// declarations, still with no explicit `function main()` anywhere - only the
+// root-level STATEMENTS (not the helper declarations) become the synthesized
+// `main` body (generateGlobalEntryCode in MLIRGenModule.cpp); the helpers stay
+// ordinary top-level declarations, callable from that synthesized body exactly
+// like they'd be callable from a hand-written main().
+
+function double(x: number): number {
+    return x * 2;
+}
+
+class Box {
+    value: number;
+    constructor(v: number) {
+        this.value = v;
+    }
+    get(): number {
+        return this.value;
+    }
+}
+
+const results: number[] = [];
+for (let i = 1; i <= 3; i++) {
+    results.push(double(i));
+}
+assert(results[0] == 2 && results[1] == 4 && results[2] == 6, "helpers-from-root");
+
+const box = new Box(21);
+assert(double(box.get()) == 42, "class-and-function-mixed");
+
+print("done.");

--- a/tslang/test/tester/tests/export_function.ts
+++ b/tslang/test/tester/tests/export_function.ts
@@ -1,0 +1,34 @@
+namespace M {
+
+    // Cross-module counterpart to 01arguments.ts / 00funcs.ts, but for a plain
+    // (non-generic) function - every other declaration kind (class, interface,
+    // enum, vars) has both a "-generic" and a plain cross-module export/import
+    // test pair; function only had "-generic" (import_function_generic.ts).
+    // Covers what DeclarationPrinter's printFunction/printParams must round-trip
+    // correctly through __decls: a required param, an optional param (`?`), a
+    // default-valued param, and a void return.
+
+    export function add(a: number, b: number): number {
+        return a + b;
+    }
+
+    export function greet(name: string, greeting: string = "Hello"): string {
+        return `${greeting}, ${name}!`;
+    }
+
+    export function maybeDouble(x: number, factor?: number): number {
+        if (factor == undefined) factor = 2;
+        return x * factor;
+    }
+
+    export function noop(): void {
+    }
+
+    // a function in the exporting module calling ANOTHER function declared in
+    // the SAME exporting module - exercises that intra-module calls still
+    // resolve correctly once this module is compiled as a dynamic-import target
+    // rather than compiled standalone (distinct from the importer calling in).
+    export function addTwice(a: number, b: number): number {
+        return add(a, b) + add(a, b);
+    }
+}

--- a/tslang/test/tester/tests/export_type_alias.ts
+++ b/tslang/test/tester/tests/export_type_alias.ts
@@ -1,0 +1,25 @@
+namespace M {
+
+    // Cross-module counterpart to decl_type.ts, but broader - every other
+    // declaration kind has both a "-generic" and a plain cross-module test
+    // pair; type alias only had "-generic" (import_type_alias_generic.ts).
+    // Covers a primitive alias, an object-shape alias, a union alias, an
+    // alias-of-alias chain, and a function whose signature uses one of these
+    // aliases (so the printed __decls text must resolve the alias by name,
+    // not just inline its expansion).
+
+    export type Id = number;
+
+    export type UserId = Id;
+
+    export type Point = {
+        x: number;
+        y: number;
+    };
+
+    export type Status = number | string;
+
+    export function makePoint(x: number, y: number): Point {
+        return { x: x, y: y };
+    }
+}

--- a/tslang/test/tester/tests/import_function.ts
+++ b/tslang/test/tester/tests/import_function.ts
@@ -1,0 +1,17 @@
+import './export_function'
+
+function main() {
+    assert(M.add(2, 3) == 5);
+
+    assert(M.greet("World") == "Hello, World!");
+    assert(M.greet("World", "Hi") == "Hi, World!");
+
+    assert(M.maybeDouble(5) == 10);
+    assert(M.maybeDouble(5, 3) == 15);
+
+    M.noop();
+
+    assert(M.addTwice(2, 3) == 10);
+
+    print("done.");
+}

--- a/tslang/test/tester/tests/import_type_alias.ts
+++ b/tslang/test/tester/tests/import_type_alias.ts
@@ -1,0 +1,20 @@
+import './export_type_alias'
+
+function main() {
+    const id: M.Id = 42;
+    assert(id == 42);
+
+    const uid: M.UserId = 7;
+    assert(uid == 7);
+
+    const p: M.Point = M.makePoint(1, 2);
+    assert(p.x == 1);
+    assert(p.y == 2);
+
+    let s: M.Status = 5;
+    assert(s == 5);
+    s = "error";
+    assert(s == "error");
+
+    print("done.");
+}


### PR DESCRIPTION
## Summary

When a file has no explicit `main()`, `generateGlobalEntryCode` (MLIRGenModule.cpp) gathers every statement not inside a function/class body and compiles it **as** the synthesized `main()` itself. ~54 existing test files incidentally rely on this (root-level `assert`/`print` calls with no `main` wrapper), but they're all short/simple — none deliberately exercised control flow at true root scope. `44toplevelcode.ts` has top-level declarations but still wraps its actual test logic in an explicit `main()`.

Also notable: a `let`/`const` declared directly at root level is module-scope storage (like a static field), not a stack local — a real difference from the normal case worth covering, especially for closures capturing it.

## Added

- `00toplevel_control_flow.ts`: `for`/`while`/`switch`/`try-catch-finally` running directly at root scope, a closure capturing a root-level `let`, and a class defined and used at root (instantiated, method called).
- `00toplevel_no_main_with_helpers.ts`: root-level statements coexisting with ordinary function/class declarations, calling into them.

Registered in both compile and jit tiers (4 new `add_test` entries), next to the existing `44toplevelcode.ts` registration.

## Investigation note

Hit what looked like a real bug along the way — JIT crashed with an uncaught C++ exception on the `try/catch` block, AOT produced no output at all. Root cause was in the *test*, not the compiler: `throw 42;` throws an integer literal, but `catch (v: number)` expects `number` (f64), and catch-by-type requires an exact type match — the exception propagated uncaught. Fixed to `throw 42.0;`, matching the established idiom in `00try_catch.ts`'s `main2()`, and confirmed passing in both tiers before adding.

## Test plan

- [x] Manually verified both new files pass in compile + JIT tiers before registering
- [x] Full `ctest -C Debug -j 8`: 827/827 passed (823 + these 4 new entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)