### PR TITLE
Register 00reference_ref_deref.ts, found via an orphaned-test-file audit

### DIFF
--- a/tslang/test/tester/CMakeLists.txt
+++ b/tslang/test/tester/CMakeLists.txt
@@ -481,6 +481,9 @@ add_test(NAME test-compile-internals COMMAND test-runner "${PROJECT_SOURCE_DIR}/
 add_test(NAME test-compile-load-store-decorators COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/load_store_decorators.ts")
 add_test(NAME test-compile-reference-null-bug COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_null_bug.ts")
 add_test(NAME test-compile-reference-index-bug COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_index_bug.ts")
+# present on disk but never wired into any add_test - found while auditing for orphaned
+# test files; compiles and passes cleanly in both tiers, exercises Ref<T>/Deref semantics
+add_test(NAME test-compile-reference-ref-deref COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_ref_deref.ts")
 add_test(NAME test-compile-uint-compare-bug COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/00uint_compare_bug.ts")
 add_test(NAME test-compile-gc-malloc-cse-o3 COMMAND test-runner "${PROJECT_SOURCE_DIR}/test/tester/tests/gc_malloc_cse_o3.ts")
 add_test(NAME test-compile-fast-math COMMAND test-runner -fast-math "${PROJECT_SOURCE_DIR}/test/tester/tests/fast_math.ts")
@@ -849,6 +852,7 @@ add_test(NAME test-jit-internals COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}
 add_test(NAME test-jit-load-store-decorators COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/load_store_decorators.ts")
 add_test(NAME test-jit-reference-null-bug COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_null_bug.ts")
 add_test(NAME test-jit-reference-index-bug COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_index_bug.ts")
+add_test(NAME test-jit-reference-ref-deref COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00reference_ref_deref.ts")
 add_test(NAME test-jit-uint-compare-bug COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/00uint_compare_bug.ts")
 add_test(NAME test-jit-gc-malloc-cse-o3 COMMAND test-runner -jit "${PROJECT_SOURCE_DIR}/test/tester/tests/gc_malloc_cse_o3.ts")
 add_test(NAME test-jit-fast-math COMMAND test-runner -jit -fast-math "${PROJECT_SOURCE_DIR}/test/tester/tests/fast_math.ts")


### PR DESCRIPTION
## Summary

Audited every `.ts` file under `test/tester/tests/` for ones never referenced by any `add_test()` in CMakeLists.txt — found 4:

- `00switch_state.ts`: genuinely broken (references an unresolvable `switchstate` builtin, fails to compile) — correctly left unregistered.
- `raytrace-0.ts`: genuinely broken (strict-null-mode violation, missing the `@strict-null false` pragma other tests use) — an older variant superseded by the working `raytrace.ts`, correctly left unregistered.
- `declare_global_var.ts`: a false positive — it IS used, just indirectly via an in-source `/// <reference path="declare_global_var.ts" />` directive in `include_global_var.ts` (this compiler actually processes that directive as a real inclusion, unlike upstream TypeScript where it's just an IDE hint) rather than as a second test-runner argument. Confirmed by briefly "fixing" the reference to point at the file that IS passed as a second argument (`define_global_var.ts`) — that broke the build with a duplicate-symbol linker error, so reverted.
- `00reference_ref_deref.ts`: a genuine gap. Compiles and passes cleanly in both compile and jit tiers, exercises `Ref<T>`/`Deref` reference semantics. Registered as `test-compile-reference-ref-deref` / `test-jit-reference-ref-deref`.

## Test plan

- [x] Full `ctest -C Debug -j 8`: 829/829 passed (827 + these 2 new entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)