### PR TITLE
Fix ~30 more crashes across §5.1/§5.2 of the not-implemented audit

### DIFF
--- a/tslang/docs/not-implemented-audit.md
+++ b/tslang/docs/not-implemented-audit.md
@@ -1,18 +1,33 @@
 # `llvm_unreachable("not implemented")` audit
 
-Status: **12 confirmed crashes fixed across six passes, ~103 markers still
-uninvestigated** — written as a roadmap for continuing this audit, not a
-claim that the sweep is complete. Triggered by a user request to review
-every "not implemented" marker in the codebase and see which ones can be
-implemented. Second pass (§4.3-4.5) worked through this document's own §6
-priority list while waiting on the first pass's PR to merge. Third pass
-(§4.6-4.8) closed out §5.4's `MLIRTypeHelper.h` `funcRef` family after that
-PR merged. Fourth pass (§4.9) closed out `MLIRGenCast.cpp`'s two `TypeOf`
-sites, the last item left from the original §5.1 named/specific list. Fifth
-pass (§4.10) started the `MLIRGenImpl.h` cluster (§5.1's last remaining
-block), closing 4 of its sites. Sixth pass (§4.11) closed 3 more sites in
-the same cluster, including two real, easily-reachable `import X = ...`
-crashes.
+Status: **§5.1 and §5.2 are now both fully closed; only §5.3 (RTTI, ~19
+sites, lowest priority) and a handful of stray `MLIRTypeHelper.h` lines
+(§5.4) remain uninvestigated** — written as a roadmap for continuing this
+audit, not a claim that the sweep is complete (§5.2's generic fallbacks
+were themselves only a guess at what's left; more may turn up by re-grepping
+after this many edits). Triggered by a user request to review every "not
+implemented" marker in the codebase and see which ones can be implemented.
+Second pass (§4.3-4.5) worked through this document's own §6 priority list
+while waiting on the first pass's PR to merge. Third pass (§4.6-4.8) closed
+out §5.4's `MLIRTypeHelper.h` `funcRef` family after that PR merged. Fourth
+pass (§4.9) closed out `MLIRGenCast.cpp`'s two `TypeOf` sites, the last item
+left from the original §5.1 named/specific list. Fifth pass (§4.10) started
+the `MLIRGenImpl.h` cluster (§5.1's last remaining block), closing 4 of its
+sites. Sixth pass (§4.11) closed 3 more sites in the same cluster, including
+two real, easily-reachable `import X = ...` crashes. Seventh pass (§4.12)
+closed the rest of §5.1: `MLIRGenImpl.h`'s last 2 sites,
+`MLIRGenInterfaces.cpp`'s remaining 2, the entire `MLIRGenTypes.cpp` cluster
+(10 sites), and `LLVMCodeHelper.h:452` - plus 2 bonus fixes found along the
+way that weren't in the original grep (a `return nullptr;`-as-`std::string`
+UB crash, and the `MLIRGenImpl.h:7907` object-literal twin this doc had left
+un-patched after calling it dead). Eighth pass (§4.13) closed all of §5.2 -
+every generic `TypeSwitch::Default`/switch fallback this doc had inventoried
+across 12 files - finding several more real, easily-reachable crashes along
+the way (array-to-`any[]` widening, `class`/`interface extends`ing the wrong
+kind of type, accessor `++`/`--`, generic-call type-argument inference
+failure, destructuring assignment gaps) plus one gap found by diffing
+against a type list rather than reproducing a crash (`MLIRTypeIterator.h`
+was missing `NamespaceType` entirely).
 
 ## 1. Scope and method
 
@@ -539,6 +554,395 @@ parser; left as genuinely unread rather than assumed dead.
 Verified via repro (both real crashes) and the full suite: `ctest -C Debug
 -j8` → 829/829, no regressions.
 
+### 4.12 Seventh pass — closes §5.1 entirely: `MLIRGenImpl.h`'s last 2 sites, `MLIRGenInterfaces.cpp`'s remaining 2, all of `MLIRGenTypes.cpp` (10 sites), `LLVMCodeHelper.h:452`, plus 2 bonus finds
+
+**`MLIRGenImpl.h:8164` (`processTypeParameter`) and `:8382`
+(`mlirGen(TypeAliasDeclaration...)`)**: the two sites left open at the end
+of §4.11. Both are the "name came back empty" branch for a construct whose
+grammar requires an `Identifier` (`<T>` / `type X = ...`), so - like
+`addInterfaceMethod` before them - genuinely look parser-guaranteed
+unreachable and neither was reproduced. Fixed anyway per this audit's
+running "don't leave a landmine" policy: `mlirGen(TypeAliasDeclaration...)`
+got a trivial `emitError` swap (a `mlir::failure()` return already existed
+one line below); `processTypeParameter` needed a real code change since its
+only path back to callers is a `TypeParameterDOM::TypePtr` - callers
+(`processTypeParameters` et al.) push whatever it returns into a vector and
+later dereference it, so returning `nullptr` for "fail" would just move the
+crash one level up. Fixed by emitting the error and returning
+`std::make_shared<TypeParameterDOM>("")` - a valid, if semantically empty,
+object the caller can hold without crashing.
+
+**`MLIRGenInterfaces.cpp`'s two remaining sites** (this doc's original
+:475/:932/:954 - line numbers drifted from PR #302, which had already fixed
+the middle one, "unsupported interface member", before this pass started):
+
+- **The `extends` heritage-clause `TypeSwitch::Default` (interface
+  extending a non-InterfaceType/TupleType target): a real, confirmed
+  crash.** `interface X extends SomeClass {}` - real, documented TypeScript
+  (extending an interface from a class's instance shape) - hit this
+  immediately (confirmed via the "idle-CPU-but-actually-blocked-on-an-
+  invisible-abort-dialog" pattern from [[windows-assert-dialog-looks-like-hang]],
+  same as §4.10's `getIntTypeAttribute` finding). Root-caused further:
+  `mth.getFields` (the same helper the `TupleType` `Case` above it already
+  called) *already* handles `ClassType`, `ConstTupleType`, `ObjectType`,
+  `ArrayType`, and `StringType` internally - so the fix was to make
+  `Default` call `mth.getFields` too (generalizing, not hand-rolling a new
+  per-type `Case`) and only `emitError` if that itself fails. This
+  incidentally fixes `ConstTupleType`/`ObjectType`/`ArrayType`/`StringType`
+  extends-targets as a side effect, not just the `ClassType` one that was
+  reproduced.
+- **`getNameForMethod`'s non-`StringAttr` computed-name branch: a real,
+  confirmed crash.** `interface X { [1](): void; }` (a constant-foldable
+  non-string computed method name) reaches this - `1` folds to a
+  `ConstantOp` with an `IntegerAttr`, which isn't a `StringAttr`. Converted
+  to `emitError` + `return {"", false}` (the same failure shape the
+  function already returns one branch above for the `mlir::failed(result)`
+  case).
+
+**Bonus find, not in the original "not implemented" grep**:
+investigating the numeric-computed-method-name repro above first hit a
+*different*, more severe crash before reaching `getNameForMethod` at all -
+`getNameWithArguments` (`MLIRGenImpl.h`, the general
+name-or-anonymous-name-synthesis helper used by every function-like
+declaration, not just interface methods) had `return nullptr;` inside a
+function returning `std::string`. That's UB: `nullptr` converts to `const
+char*`, and `std::string(const char*)` calls `strlen` on it, which
+segfaults. WinDbg/ProcDump confirmed the crash (`strlen` →
+`basic_string::basic_string<char*>` → `getNameWithArguments:9277` in the
+stack). Worse, this early return also *skipped* the anonymous-name
+synthesis fallback every other empty-name case in the same function falls
+through to - so the fix was to delete the early return entirely (not just
+guard it), letting the computed-name failure fall through to that existing
+fallback. This bug was reachable for *any* function-like declaration whose
+computed name fails to resolve (not just the specific interface-method
+repro that found it), making it plausibly the most broadly-reachable single
+bug found in this entire audit.
+
+**All 10 sites in `MLIRGenTypes.cpp`** (this doc's :183/1474/1567/1876/
+1910/2001/2204/2210/2661/3401 list, closing §5.1's last file):
+
+- **`getType(Node, ...)` master dispatcher (:183) and `getTypeByTypeName`
+  (:277, an already-exhaustive `Identifier`/`QualifiedName` EntityName
+  dispatch) and `getResolveTypeParameter(TypeParameterDeclaration...)`
+  (:250, another empty-type-parameter-name case, same shape as
+  `processTypeParameter` above)**: converted to `emitError` +
+  `mlir::Type()`/graceful-return without a repro; `getType`'s only
+  identified-but-unconfirmed gap is `ImportType` (`import("mod").Foo`,
+  grepped and confirmed unhandled anywhere in the codebase) - a real gap,
+  just not cheap to reproduce (needs a second module) so left undemonstrated.
+- **`RecordType`'s and `OmitTypes`' non-literal-key `Default`/`else`
+  branches (:1474, :1567): confirmed dead code**, by the same call-site-
+  trace method §4.6-4.8 used for the `funcRef` family. `Record<K,T>`,
+  `Pick<T,K>`, `Omit<T,K>`, `Exclude<T,U>`, `Extract<T,U>` are *all*
+  declared as ordinary generic type aliases in the default lib
+  (`lib.generics.ts`, e.g. `type Record<K extends string|number|symbol, T> =
+  { [P in K]: T }`), and `getTypeByTypeReference` always tries
+  `resolveGenericType` before ever reaching the builtin-fallback family
+  these two functions belong to (`getEmbeddedTypeWithManyParamsBuiltins`) -
+  confirmed live by testing `Record<string,V>`/`Record<number,V>` and
+  watching them route through the mapped-type machinery (a *different*,
+  unrelated "mapped type is empty for constrain" warning) instead of
+  crashing. Fixed to no-op (matching `PickTypes`' sibling
+  `pickTypesProcessKey`, which already silently ignores an unrecognized key
+  shape) rather than crash, for the "don't leave a landmine" reason, not
+  because either is expected to ever actually run.
+- **`getMappedType`'s two `Default`/`else` branches for `as`-remapped
+  mapped-type keys (:2204, :2210): unconfirmed, converted defensively.**
+  These fire only when a mapped type's `as` name-remapping clause produces
+  a shape (non-literal, or a union/non-union mismatch against the value
+  type) that couldn't be constructed from a simple repro attempt in the
+  time available; left as genuinely untested rather than claimed dead,
+  same honesty standard as the rest of this document.
+- **`getTypeOperator`'s final fallthrough (:1876): grammar-exhaustive**
+  (`unique`/`keyof`/`readonly` are the only three TS type-operator
+  keywords, all three handled above) - converted defensively, no repro
+  expected to exist.
+- **`getIndexedAccessType`'s `StringType`-index branch (:1910): a real,
+  confirmed crash.** `type X = Foo[string]` (indexing a type by the general
+  `string` type rather than a specific literal key - invalid in real TS
+  unless the target has a string index signature, which this compiler's
+  indexed-access resolution doesn't model) crashed instantly. This function
+  had no `mlir::Location` parameter at all (nor did its 3 recursive
+  self-calls or its `IndexedAccessTypeNode` entry point) - threaded one
+  through the whole call chain (5 call sites total, all in this file) rather
+  than falling back to some contextless diagnostic.
+- **`getIndexedAccessType`'s final fallthrough (:2001), same function,
+  same location threading applies**: unconfirmed (nothing tried reached
+  it), converted defensively using the same threaded `location`.
+- **`getTupleFieldInfo(TypeLiteralNode...)`'s member-kind `else` (:2661): a
+  real, confirmed, easily-reachable crash.** A `TypeLiteral`
+  (`type X = { ... }`) resolves to this compiler's plain-value `TupleType`
+  representation, and this function only handled
+  `PropertySignature`/`MethodSignature`/`ConstructSignature`/
+  `IndexSignature`/`CallSignature` - missing `GetAccessor`/`SetAccessor`,
+  which real TS type literals do support (`type X = { get foo(): number }`).
+  Confirmed via repro. Unlike `InterfaceDeclaration` (which has its own
+  accessor/vtable machinery in `MLIRGenInterfaces.cpp`), a `TupleType` has
+  no getter/setter dispatch representation to plug an accessor into at all
+  - implementing this for real is a separate, scoped feature (same
+  "real gap, not dead code, out of scope for a crash-audit pass" category
+  as §4.2's array/union spread and §4.9's union-tuple `TypeOf` cast).
+  Converted to a clean `emitError` instead. The final catch-all `else`
+  (any *other* unhandled member kind) got the same treatment.
+- **`getLiteralType(LiteralTypeNode...)`'s final fallthrough (:3401):
+  unconfirmed.** Tried negative numeric literals (`-1`) and `BigIntLiteral`
+  (`100n`) as plausible triggers - both already handled cleanly (fold to a
+  `ConstantOp` before reaching this point). Converted defensively without a
+  confirmed repro.
+
+**`LLVMCodeHelper.h:452` (`getArrayValue`'s final fallthrough, LLVM-lowering
+stage): unconfirmed, likely dead per this doc's own earlier hypothesis.**
+Tried an array of `null` elements and a mixed `number|string` union array as
+plausible triggers for an unhandled const-array-literal element type -
+neither reached this branch (both already handled by earlier cases in the
+same function). This file has zero prior `emitError`-style diagnostics
+anywhere in it (this pass of the audit is LLVM-lowering-stage code, past
+the point normal MLIRGen diagnostics are emitted) - used the `op->emitError`
+idiom instead (confirmed as a live pattern via `LowerToLLVM.cpp`'s own
+debug-assert error calls) plus a `return mlir::Value()`, rather than
+`llvm_unreachable`.
+
+**Bonus fix, the twin this document itself had already flagged**:
+`MLIRGenImpl.h:7907` ("object literal is not implemented(1)") - §5.1's table
+entry for `LLVMCodeHelper.h:452` speculated this was its already-confirmed-
+dead MLIRGen-level twin, but the `llvm_unreachable` itself had never
+actually been replaced. Verified the grammar-exhaustiveness claim by reading
+`mlirGenObjectLiteralFields`'s full dispatch (`PropertyAssignment`|
+`ShorthandPropertyAssignment`|`SpreadAssignment`|`MethodDeclaration`|
+`GetAccessor`|`SetAccessor` - the complete `ObjectLiteralElementLike`
+grammar) and converted it to the standard `emitError` + graceful-failure
+shape while here, rather than leave the confirmed-dead crash in place.
+
+Verified: every confirmed-crash repro re-run clean after the fix (no
+crashes, clean diagnostics), plus the full suite: `ctest -C Debug -j8` →
+**829/829, no regressions**.
+
+### 4.13 Eighth pass — closes §5.2 entirely (12 files), several more real crashes found
+
+Worked through every site in §5.2's inventory list, file by file, using the
+same repro-when-possible / defensive-fix-when-not approach as every prior
+pass. Rebuilt and ran the full suite after each file (not just once at the
+end) specifically so a bad fix would be caught close to its cause; 829/829
+green after every single rebuild in this pass, no regression ever surfaced.
+
+**`CastLogicHelper.h` (LLVM-lowering-stage `cast()` helper), 7 sites**:
+
+- **`castToArrayType`'s final `else` (was :1002): a real, easily-reachable
+  crash.** Widening `number[]` to an `any[]` function parameter (an entirely
+  ordinary pattern) crashed - the function only ever handled a source that
+  was itself `ConstArrayType`/`NullType`/`UndefinedType`, never a plain
+  dynamic `ArrayType`. Properly supporting it needs a runtime per-element
+  boxing loop (`number` and boxed `any` aren't bit-compatible) - a separate,
+  scoped feature, not a quick fix. Converted to a clean `emitError`.
+- **The other 6 sites (array-to-string, tuple-to-interface ×2, union-to-
+  boolean-with-RTTI-tag, optional-to-other-type), all marked "must be
+  processed at MLIR pass": confirmed dead or blocked upstream, not
+  reproduced.** Array-to-string and tuple-to-interface casts were confirmed
+  to already work end-to-end via direct JIT repros without ever reaching
+  these branches (they're resolved by a dedicated MLIR-level pass/pattern
+  before LLVM lowering, exactly as their own comment says). The union-to-
+  boolean case is blocked one stage earlier by MLIRGen's own union-to-
+  boolean rejection (`castFromUnion`, §4.9) - confirmed via two repro
+  attempts (`if (x)` and `!!x` where `x: number | {a: number}`), both
+  already fail cleanly before LLVM lowering runs. The optional-to-other-type
+  case wasn't reproduced despite two attempts (widening to a broader union,
+  casting through `any`). All 6 converted to `emitError` defensively.
+
+**`MLIRGenClasses.cpp`, 5 sites**:
+
+- **The `extends` and `implements` heritage-clause `TypeSwitch::Default`s
+  (was :603, :635, plus :1802's mirror of the `implements` one): both real,
+  confirmed crashes.** `class Sub extends SomeInterface {}` (real TS itself
+  rejects extending an interface, but this compiler didn't check) and
+  `class Square implements SomeTypeAlias` where the alias resolves to an
+  object-shape `TupleType` rather than a declared interface (real, valid,
+  common TypeScript - this compiler's `implements` only accepts a genuine
+  `InterfaceType`, so this is a real gap, not an error case). Fixing the
+  `extends` one surfaced a **second bug in the same spot**: the original
+  code had no failure-tracking at all in that loop (unconditionally
+  `return mlir::success()` regardless of which `TypeSwitch` case fired), so
+  the first attempt's `emitError` was silently swallowed - the repro
+  compiled "successfully" with the class heritage just quietly dropped.
+  Caught by testing the exact repro after the fix (not just the full
+  suite), per §4.11's own lesson about second bugs one level up. Added a
+  `success` bool matching the sibling `implements` branch's existing
+  pattern.
+- **Two empty-member-name guards (was :2269, :2306): unconfirmed.** Tried a
+  computed class-property initializer (`class X { [key] = 42; }`) and a
+  parameter-property combined with a destructuring pattern
+  (`constructor(public {x,y}: T)`, itself invalid real TS - TS2369) as
+  plausible triggers; both hit a *different*, undocumented crash first (an
+  LLVM `Casting.h` `dyn_cast on a non-existent value` assertion, in
+  `getNameWithArguments`'s computed-property-name path or nearby - not
+  chased further, out of this audit's "not implemented" scope, noted here
+  as a discovered-but-unfixed bug for a future pass). Converted both
+  defensively regardless.
+
+**`MLIRGenExpressions.cpp`, bonus find + 3 sites**:
+
+- **Bonus, not in the original grep**: the master `mlirGen(Expression...)`
+  dispatcher's final `llvm_unreachable("unknown expression")` (a different
+  message, missed by the original `"not implemented"` grep) - found while
+  investigating the ctor-destructuring-parameter-property repro above.
+  Reachable via that exact same invalid-but-unchecked pattern (a
+  `BindingPattern` name node, not an `Expression` kind, reaching this
+  dispatcher). Converted to `emitError`.
+- **`mlirGen(DeleteExpression...)`'s final `else` (was :996): a confirmed
+  real crash on first repro, but not reproducible afterward.** `delete
+  obj.a` on a plain mutable-tuple object literal crashed on the first
+  attempt (`UNREACHABLE executed at ...:996!`, exact repro, exact line) -
+  but re-running the identical repro after the fix (and several variants:
+  `const` instead of `let`, an rvalue tuple from a function call) never
+  reached the new code path at all; property access on a tuple value
+  apparently always yields a `RefType`, which this branch's guarding `if`
+  already excludes. Genuinely unclear why the first run differed - noted
+  honestly rather than claimed as a confirmed live bug. Fixed anyway
+  (real TS itself rejects deleting a non-optional property, TS2790 - this
+  compiler doesn't check that either, and there's no way to "delete" a
+  fixed-layout tuple field regardless): `emitError` instead of crash.
+- **Prefix/postfix unary operator `default` branches (was :538, :560):
+  grammar-exhaustive** (`+ - ~ ! ++ --` prefix, `++ --` postfix are the
+  complete TS operator sets, all handled above) - converted defensively,
+  no repro expected to exist.
+
+**`MLIRGenGenerics.cpp`, 4 sites**:
+
+- **`instantiateSpecializedFunction`'s type-argument-resolution `else`
+  (was :911, in the middle of the file's numbering): a real, confirmed
+  crash.** `function foo<T>(): T { ... }` called as `foo()` - no explicit
+  type argument, and nothing to infer `T` from (zero parameters, zero call
+  operands). Real TS rejects this too ("type argument cannot be inferred
+  from usage"). Converted to a clean `emitError`.
+- **Three more (function-ref-shape dispatch ×2, a `CreateBoundFunctionOp`
+  result-type switch): unconfirmed or construction-guaranteed.** The
+  `CreateBoundFunctionOp` one is dead by construction (that op's result can
+  only ever be `BoundFunctionType`/`HybridFunctionType`, both handled).
+  The other two (a generic function reference that's neither wrapped in
+  `CreateBoundFunctionOp` nor a bare `SymbolRefOp`/`ThisSymbolRefOp`) each
+  had one plausible trigger tried (a generic function assigned to a
+  variable then called; `super.genericMethod(...)`) and neither reached the
+  crash - both resolve through the already-handled paths. Converted
+  defensively.
+
+**`MLIRGenImpl.h`'s §5.2 cluster, 7 sites**:
+
+- **`mlirGenSaveLogicArray`'s and `mlirGenSaveLogicObject`'s
+  `TypeSwitch`/dispatch `Default`s (destructuring-assignment codegen,
+  2 sites): both real, confirmed crashes.** `[a, b] = "hi"` (array-
+  destructuring from a string - this compiler's destructuring-assignment
+  codegen only positionally indexes Array/ConstArray/Tuple/ConstTuple, never
+  gained the iterator-protocol handling `for...of` has) and `({ a, ...rest
+  } = obj)` (rest-destructuring in an object-destructuring assignment - a
+  real, separate missing feature, same shape as §4.2's object-literal
+  spread gap: synthesizing `rest` needs enumerating every not-yet-
+  destructured field). Both converted to clean `emitError`s; the array one
+  needed an added `hasUnsupportedType` flag since the original code had no
+  failure path out of that `TypeSwitch` either (same "silently swallowed"
+  risk as the `MLIRGenClasses.cpp` extends fix above - caught this time
+  before testing, not after).
+- **The switch-case jump-op dispatch, the prefix-unary-on-constant switch,
+  and a nested nested-`isDynamicImport` RTTI branch (3 sites): construction-
+  or call-site-guaranteed dead**, all converted defensively without a
+  repro attempt (the jump-op one only ever receives a `CondBranchOp`/
+  `BranchOp` by construction two lines below; the constant-unary switch's
+  only caller already guards with the same 4-operator check; the RTTI one
+  is nested inside `isDynamicImport`, itself an untested feature path per
+  §4.10).
+- **The spread-iterator-protocol `TypeSwitch`/`else` pair (`hasIterator`
+  and `processArrayValuesSpreadElement`, 2 sites each = the remaining
+  entries): the array-spread one is a real, confirmed crash.**
+  `[...new MyIter()]` where `MyIter`'s `next(): any` (a custom iterator
+  whose `next()` return type isn't a `Tuple`/`ConstTuple`) crashed in
+  `processArrayValuesSpreadElement`. The `for...of` sibling (`hasIterator`)
+  wasn't reproduced with the identical class (a `for (let x of
+  new MyIter())` repro hit an unrelated, pre-existing "any"-property-
+  resolution error first) but shares the exact same `TypeSwitch` shape, so
+  fixed identically. Both `Default` branches now treat an unrecognized
+  `next()` return shape as "not a well-formed iterator" (return
+  `false`/`emitError`) rather than crash.
+
+**`CodeLogicHelper.h:241` (`saveResult`, LLVM-lowering-stage `++`/`--`
+codegen): a real, confirmed crash, and the oldest-documented gap in this
+whole audit** - the function's own comment already said `// TODO: finish it
+for field access` before this pass touched it. `b.v++` where `v` is a
+get/set accessor pair (not a plain field) crashed: a plain variable/field
+increment loads through a `LoadOp` and stores straight back to its
+reference, but an accessor has no reference to store to - it would need
+calling the setter with the incremented value instead, a real, separate
+feature. Plain `obj.field++` (the common case) was confirmed to already
+work fine first, to isolate exactly what the TODO was still missing.
+Converted to `mlir::emitError` (this file had no prior diagnostic-emission
+precedent at all, unlike the sibling LLVM-lowering helpers).
+
+**`OptionalLogicHelper.h` and `UndefLogicHelper.h`, 4 sites total
+(2 each): confirmed dead by call-site trace, same method as the `funcRef`
+family (§4.6-4.8).** Both files' `switch (opCmpCode) { ... default:
+llvm_unreachable }` pairs handle exactly the 8 comparison `SyntaxKind`s
+(`== === != !== > >= < <=`); traced every path `opCmpCode` can take back to
+`LowerToLLVM.cpp`'s `LogicalBinaryOpLowering`, which dispatches via a
+`switch` over the identical 8-way set before ever calling into either
+helper - the `default` branches are unreachable for as long as those two
+switches stay in sync. Converted to `mlir::emitError`/`op->emitError`
+defensively rather than left crashing.
+
+**`MLIRCodeLogic.h`, 4 sites: unconfirmed, converted defensively.**
+An enum-member constant-attribute dispatch (`StringAttr`/`IntegerAttr`/
+`FloatAttr`/`BoolAttr` handled, matching the string/numeric-literal-only
+grammar for TS enum members) and three property-access helpers
+(`Ref`/`Object`/`Class`) whose non-tuple/non-`ClassStorageType` branches
+look reachable only through deep, already-extensively-tested class/object/
+array property-access machinery; no repro attempt succeeded in the time
+available. All four converted to `emitError` + a null-value return (the
+enum one additionally needed an early-return guard added after the
+`TypeSwitch`, since constructing a `LiteralType` from a null base type
+afterward would just move the crash one line down).
+
+**`MLIRPrinter.h:303` (`printAttribute`'s `Default`): likely a real gap,
+not reproduced.** Handles `StringAttr`/`FlatSymbolRefAttr`/`IntegerAttr`/
+`FloatAttr` but not `mlir::BoolAttr` - and `MLIRCodeLogic.h`'s own enum-
+attribute dispatch (just above) treats `BoolAttr` as a *separate* case from
+`IntegerAttr` in this codebase, suggesting a boolean-valued attribute
+wouldn't already be caught by the `IntegerAttr` case here either. No
+repro found in the time available. Changed to fall back to the
+attribute's own default printer (`out << a;`), matching the sibling
+`printType`'s own `Default` two dozen lines below (already non-crashing,
+`out << t;` - was mis-flagged as still-crashing in this doc's §5.2
+inventory; it wasn't).
+
+**`MLIRTypeIterator.h:404`: not a "convert the crash" fix - a genuine,
+previously-undetected missing `Case`, found by diffing against
+`TypeScriptTypes.td`'s full type list rather than by reproducing a
+crash.** This recursive type-walker (used by `isGenericType`/
+`hasInferType`/`forEachTypes`/`getAllInferTypes` - i.e. called on nearly
+every resolved type throughout the whole compiler) had `Case`s for every
+one of this compiler's ~45 `mlir_ts::*Type` kinds *except*
+`NamespaceType`. Grepped every `TypeScript_*` type def in
+`TypeScriptTypes.td` and diffed against every `Case<mlir_ts::...Type>` in
+this switch to find the gap - the same technique §4.6-4.8 used for the
+`funcRef` family, just applied to a type-list instead of a call-site list.
+Added the missing `Case` (a leaf type - just a name, nothing to recurse
+into) rather than merely guarding the `Default`; also softened the
+`Default` itself to a debug log instead of a crash, in case some other
+type is still missing. Not confirmed via a live crash repro (a namespace-
+qualified generic class instantiation, `NS.Box<T>`, was tried but the fix
+was already in place by the time it ran) - documented honestly as a
+static-analysis fix, not a reproduced one.
+
+**`Win32ExceptionPass.cpp:584` (`getCallBundleFromCatchRegion`'s final
+`else`): confirmed dead by construction, matching this file's own existing
+convention for the identical invariant.** Every `CatchRegion` gets exactly
+one of `catchPad`/`cleanupPad` set, at the exact site that first identifies
+it (two `CatchPadInst::Create` call sites vs. one `CleanupPadInst::Create`,
+mutually exclusive) - and this same file already asserts precisely this
+invariant twice elsewhere (lines 393, 426) rather than treating it as a
+diagnosable error. Matched that existing convention (`assert(...)`) instead
+of introducing a new diagnostic pattern in a raw LLVM-IR pass that had
+never used one.
+
+Verified: every confirmed-crash repro re-run clean after its fix, plus the
+full suite after *every* file's fixes in this pass (not just once at the
+end): `ctest -C Debug -j8` → **829/829, no regressions**, every single time.
+
 ## 5. Inventory of remaining markers (untested this pass)
 
 Grouped by file. "Shape" is a guess from reading the surrounding code, not a
@@ -557,31 +961,40 @@ dead (guarded), one a real crash (union with a tuple-shaped member).
 previous pass** (§4.11): `MLIRGenImpl.h`'s next three sites (was
 8400/8426/9342 - `import X = require(...)`, `import X = <non-namespace/
 class/interface>`, and `addInterfaceMethod`'s empty-name guard) — 2 real
-crashes, 1 defensive/unverified.
+crashes, 1 defensive/unverified. **§5.1 is now fully closed** (§4.12,
+seventh pass): `MLIRGenImpl.h`'s last 2 sites, `MLIRGenInterfaces.cpp`'s
+remaining 2 (the middle one, :932, had already been fixed by PR #302 before
+this pass started), the entire `MLIRGenTypes.cpp` cluster (10 sites), and
+`LLVMCodeHelper.h:452` (plus its `MLIRGenImpl.h:7907` MLIRGen-level twin,
+which turned out to still be an un-patched crash despite this doc's own
+earlier "confirmed-dead" note about it). No `.cpp`/`.h` named/specific
+marker with a message naming its trigger remains as `llvm_unreachable`
+today - what's left is exclusively §5.2's generic `TypeSwitch::Default`
+fallbacks and §5.3's RTTI fallbacks, both harder to triage because they
+carry no clue about their trigger beyond the enclosing type switch.
 
-| Site | Message | Shape (unverified guess) |
-| --- | --- | --- |
-| `MLIRGenImpl.h:8164` | not implemented | unread — `processTypeParameter`'s empty-name branch, likely parser-grammar-unreachable but not verified |
-| `MLIRGenImpl.h:8382` | not implemented | unread — `TypeAliasDeclaration`'s empty-name `else`, likely parser-grammar-unreachable but not verified (the other two of the original "three close together" trio, 8400/8426, were fixed in §4.11) |
-| `MLIRGenInterfaces.cpp:475` | not implemented yet | unread |
-| `MLIRGenInterfaces.cpp:932` / `:954` | not implemented | unread |
-| `MLIRGenTypes.cpp:183` | not implemented type declaration | unread |
-| `MLIRGenTypes.cpp:1474` / `:1567` / `:1876` / `:1910` / `:2001` / `:2204` / `:2210` / `:2661` / `:3401` | not implemented | unread, largest single-file cluster after MLIRGenImpl.h |
-| `LLVMCodeHelper.h:452` | array literal is not implemented(1) | likely the LLVM-lowering-side twin of the (confirmed-dead) `MLIRGenImpl.h:7875` "object literal is not implemented(1)" `else` branch — check the same way (is there any other `SyntaxKind` an array-literal element list can produce?) |
+The table this section used to carry (unread sites) is gone - all of it is
+now covered by §4.10-§4.12 above. See §4.12 for real-vs-dead-vs-unconfirmed
+verdicts on every site, and the `MLIRTypeHelper.h` stray lines noted in §5.4
+below for the one still-unread pocket adjacent to this list.
 
-### 5.2 Generic `TypeSwitch::Default` exhaustiveness fallbacks (likely mostly dead, per §3's precedent — verify by checking whether an existing passing test already produces the relevant `mlir::Type` at that pipeline stage)
+### 5.2 Generic `TypeSwitch::Default` exhaustiveness fallbacks — CLOSED this pass, see §4.13
 
-`MLIRGenClasses.cpp:603,635,1802,2269,2306` · `MLIRGenExpressions.cpp:530,552,988` ·
-`MLIRGenGenerics.cpp:424,542,911,1342` · `MLIRGenImpl.h:3203,3477,3803,4402,4518,6379,7080,7094` ·
-`MLIRGenInterfaces.cpp:656` · `CastLogicHelper.h:338,344,353,359,460,487,1002` (four of these say
-"must be processed at MLIR pass" — suggests a *specific*, documented reason
-they should be unreachable at the LLVM-lowering stage, worth reading before
-assuming they're arbitrary) · `CodeLogicHelper.h:241` · `OptionalLogicHelper.h:143,213` ·
+Every site originally listed here (`MLIRGenClasses.cpp:603,635,1802,2269,2306` ·
+`MLIRGenExpressions.cpp:530,552,988` · `MLIRGenGenerics.cpp:424,542,911,1342` ·
+`MLIRGenImpl.h:3203,3477,3803,4402,4518,6379,7080,7094` ·
+`MLIRGenInterfaces.cpp:656` · `CastLogicHelper.h:338,344,353,359,460,487,1002` ·
+`CodeLogicHelper.h:241` · `OptionalLogicHelper.h:143,213` ·
 `UndefLogicHelper.h:74,107` · `MLIRCodeLogic.h:1218,1660,1680,1722` ·
-`MLIRPrinter.h:302-303,534` (type-name printing — a `Default` here would show
-up immediately as a printer test failure, so likely easy to check against
-`unittests/MLIRGen/TypeToString.cpp`'s existing coverage) · `MLIRTypeIterator.h:403-404` ·
-`Win32ExceptionPass.cpp:584`.
+`MLIRPrinter.h:302-303,534` · `MLIRTypeIterator.h:403-404` ·
+`Win32ExceptionPass.cpp:584`) is now fixed - see §4.13 for the full
+real/dead/unconfirmed breakdown per site. `MLIRGenInterfaces.cpp:656` turned
+out to already be resolved as a side effect of §4.12's interface-extends
+fix, before this pass even started touching it directly.
+
+This was this doc's own inventory of §5.2, not an exhaustive repo grep run
+fresh - a new sweep might turn up more generic fallbacks this list never
+included (see §7's caveat).
 
 ### 5.3 RTTI type-switch fallbacks (Windows/Linux variants — the Linux ones can't be exercised from this Windows dev box without a Linux/WSL build)
 
@@ -638,21 +1051,39 @@ bug (the built-in utility types); tracing real callers is what worked.
    from §5.1, plus the stray
    `MLIRTypeHelper.h:410/420/2108/2256-2257/2290/2307/2685/2709` sites
    (confirmed *not* part of the `funcRef` family, see §5.4).
-5. **In progress**: the `MLIRGenImpl.h`/`MLIRGenInterfaces.cpp`/
-   `MLIRGenTypes.cpp` cluster (§5.1's last remaining block) — read-and-repro
-   each per §2's recipe. §4.10 closed the first 4 `MLIRGenImpl.h` sites
-   (5330/6732/7314/7418); §4.11 closed 3 more (8400/8426/9342, 2 of them
-   real `import X = ...` crashes); still open: `MLIRGenImpl.h:8164/8382`
-   (both look parser-grammar-unreachable but unverified), all of
-   `MLIRGenInterfaces.cpp` (475/932/954), all of `MLIRGenTypes.cpp`
-   (183/1474/1567/1876/1910/2001/2204/2210/2661/3401), and
-   `LLVMCodeHelper.h:452`.
-6. §5.2 (generic fallbacks) — triage a handful against existing passing
-   tests using §3's method before assuming any individual one is live.
-7. §5.3 (RTTI) — lowest priority from this (Windows) machine; the Linux
-   variants need a WSL/Linux build to exercise at all, and even the Windows
-   ones are deep in a code path (RTTI/exception typeinfo generation) that's
-   hard to reach without a specific class-hierarchy-plus-exception scenario.
+5. ~~The `MLIRGenImpl.h`/`MLIRGenInterfaces.cpp`/`MLIRGenTypes.cpp` cluster
+   (§5.1's last remaining block)~~ — **done, §5.1 is now fully closed**.
+   §4.10 closed the first 4 `MLIRGenImpl.h` sites (5330/6732/7314/7418);
+   §4.11 closed 3 more (8400/8426/9342, 2 of them real `import X = ...`
+   crashes); §4.12 (seventh pass) closed the rest: `MLIRGenImpl.h:8164/8382`,
+   `MLIRGenInterfaces.cpp`'s 2 remaining sites, all 10 of `MLIRGenTypes.cpp`,
+   `LLVMCodeHelper.h:452`, plus 2 bonus finds (a `getNameWithArguments`
+   `return nullptr;`-as-`std::string` UB crash, and `MLIRGenImpl.h:7907`'s
+   still-unpatched "confirmed dead" object-literal twin). 829/829, no
+   regressions.
+6. ~~§5.2 (generic fallbacks)~~ — **done, §5.2 is now fully closed** (§4.13,
+   eighth pass): all 12 files' sites fixed, several real crashes found
+   (array-to-`any[]` widening, `class`/`interface` heritage-clause type
+   errors, accessor `++`/`--`, generic zero-arg inference failure,
+   destructuring-assignment gaps) plus one genuine missing `Case`
+   (`MLIRTypeIterator.h`'s `NamespaceType`) found by type-list diffing
+   rather than a repro. 829/829, no regressions, checked after every file.
+7. **Next up**: §5.3 (RTTI) — the only remaining untriaged pool, and the
+   lowest priority in this document from the start: the Linux variants need
+   a WSL/Linux build to exercise at all, and even the Windows ones are deep
+   in a code path (RTTI/exception typeinfo generation) that's hard to reach
+   without a specific class-hierarchy-plus-exception scenario.
+8. The stray `MLIRTypeHelper.h:410/420/2108/2256-2257/2290/2307/2685/2709`
+   sites (§5.4) — confirmed not part of the `funcRef` family but never
+   actually read; cheap to fold into whichever pass next touches this file.
+9. Two bugs discovered but *not* fixed this pass, out of this document's
+   "not implemented" scope but worth a dedicated look: (a) an LLVM
+   `Casting.h` `dyn_cast on a non-existent value` assertion, reachable via
+   a computed class-property initializer (`class X { [key] = 42; }`) -
+   see §4.13's `MLIRGenClasses.cpp` writeup; (b) `MLIRGenExpressions.cpp`'s
+   delete-crash reproduced exactly once and then never again across several
+   retries with the identical source - if it resurfaces, start from §4.13's
+   honest note about it rather than assuming it's fixed.
 
 ## 7. Non-goals / out of scope
 

--- a/tslang/docs/not-implemented-audit.md
+++ b/tslang/docs/not-implemented-audit.md
@@ -27,7 +27,14 @@ the way (array-to-`any[]` widening, `class`/`interface extends`ing the wrong
 kind of type, accessor `++`/`--`, generic-call type-argument inference
 failure, destructuring assignment gaps) plus one gap found by diffing
 against a type list rather than reproducing a crash (`MLIRTypeIterator.h`
-was missing `NamespaceType` entirely).
+was missing `NamespaceType` entirely). Ninth pass (§4.14) went back and
+fixed the two bugs §4.13 had explicitly found-but-not-fixed as out of
+scope - both turned out to share one root cause in `TupleFieldName()`
+(a null `mlir::Attribute` reaching an unguarded `dyn_cast`/`cast`), found
+by tracing code after a live debugger proved unable to catch either crash
+(a plain `assert()`/`abort()` raises no Win32 exception for ProcDump to
+see, and live-attaching WinDbg made the same assert pop a blocking GUI
+dialog instead, since `IsDebuggerPresent()` becomes true).
 
 ## 1. Scope and method
 
@@ -942,6 +949,77 @@ never used one.
 Verified: every confirmed-crash repro re-run clean after its fix, plus the
 full suite after *every* file's fixes in this pass (not just once at the
 end): `ctest -C Debug -j8` → **829/829, no regressions**, every single time.
+
+### 4.14 Ninth pass — fixes the two bugs §4.13 found but deliberately left unfixed
+
+§4.13 explicitly deferred two crashes as "a different category, out of this
+audit's `llvm_unreachable` scope." This pass root-caused and fixed both,
+via careful code tracing rather than a live debugger - ProcDump couldn't
+catch either crash (a plain `assert()` failure calls `abort()`, which exits
+cleanly via `_exit(3)` with no Win32 exception raised at all, so neither
+`-e` exception-monitor mode nor `-t` terminate-monitor mode captured a
+useful stack; live-attaching WinDbg to set a breakpoint made the *same*
+assert instead pop a blocking "Debug Error!" GUI dialog, since
+`IsDebuggerPresent()` becomes true - a live debugger changes this specific
+crash's behavior rather than just observing it). Abandoned the debugger
+and traced both by reading code instead - both turned out to share one
+root cause, `TupleFieldName()` in `MLIRGenTypes.cpp`.
+
+**Root cause**: `TupleFieldName(Node name, ...)` returns a null
+`mlir::Attribute` in two situations its callers didn't guard against:
+
+1. `getNameFromComputedPropertyName` fails to extract a compile-time
+   constant from a computed name (e.g. `[key]` where `key` is a `const`
+   whose value isn't directly a `ConstantOp` - referencing it takes an
+   extra symbol-resolution layer this extraction logic doesn't see
+   through) - it already emits its own clean diagnostic before returning
+   the null/failure pair, but `TupleFieldName` propagates the null
+   `Attribute` onward with no failure signal for a non-computed-name caller
+   to check.
+2. `name` is a `BindingPattern` (`ObjectBindingPattern`/`ArrayBindingPattern`)
+   rather than an `Identifier`/`ComputedPropertyName` - `MLIRHelper::getName`
+   correctly returns empty for it (patterns have no simple name), but
+   `getNameFromComputedPropertyName` only special-cases
+   `SyntaxKind::ComputedPropertyName`, so a `BindingPattern` falls through
+   to `TupleFieldName`'s own fallback path, which unconditionally does
+   `mlirGen(name.as<Expression>(), genContext)` - `.as<Expression>()` on a
+   node that isn't an `Expression` subtype at all, an invalid downcast.
+
+Both failure modes manifest identically at the call sites: a null
+`mlir::Attribute` (or an invalid AST-node cast) reaching an unguarded
+`dyn_cast<mlir::StringAttr>(...)`/`mlir::cast<mlir::StringAttr>(...)` a few
+lines later, which crashes with `Assertion failed: detail::isPresent(Val)
+&& "dyn_cast on a non-existent value"` - `dyn_cast` (unlike
+`dyn_cast_or_null`) requires its input to already be non-null/valid; none
+of the crash sites were using the `_or_null` variant.
+
+**Fix 1 - computed class-field name** (`class X { [key] = 42; }` where
+`key` doesn't fold to a `ConstantOp`): added a null-check on `TupleFieldName`'s
+result immediately in all 4 call sites inside `MLIRGenClasses.cpp`
+(`mlirGenClassDataFieldMember`, `mlirGenClassStaticFieldMember`,
+`mlirGenClassStaticFieldMemberDynamicImport`,
+`mlirGenClassConstructorPublicDataFieldMembers` - the last one's trigger is
+believed unreachable in practice since constructor parameter names can't
+actually be computed property names, but guarded anyway for consistency and
+because `dyn_cast` crashes on null regardless of how unlikely the null is).
+Each returns `mlir::failure()` early, matching `getNameFromComputedPropertyName`'s
+own already-emitted diagnostic rather than adding a second, redundant one.
+
+**Fix 2 - parameter property + destructuring pattern**
+(`constructor(public {x, y}: T) {}` - itself invalid real TypeScript,
+TS2369, but this compiler didn't check that and crashed instead of
+erroring): added a `SyntaxKind::ObjectBindingPattern`/
+`SyntaxKind::ArrayBindingPattern` check directly in `TupleFieldName` itself,
+before the unconditional `.as<Expression>()` cast - this fixes the root
+function once, benefiting all ~13 call sites across the codebase (only the
+`MLIRGenClasses.cpp` constructor-parameter path was confirmed reachable via
+repro, but the fix is at the one shared choke point rather than duplicated
+per caller).
+
+Verified: both original repros give a clean diagnostic instead of crashing
+(`"not supported 'Computed Property Name' expression"` for fix 1,
+`"a binding pattern cannot be used as a field name"` for fix 2), plus the
+full suite: `ctest -C Debug -j8` → **829/829, no regressions**.
 
 ## 5. Inventory of remaining markers (untested this pass)
 

--- a/tslang/include/TypeScript/LowerToLLVM/CastLogicHelper.h
+++ b/tslang/include/TypeScript/LowerToLLVM/CastLogicHelper.h
@@ -333,30 +333,41 @@ class CastLogicHelper
                 return castTupleToString<mlir_ts::TupleType>(in, inType, tupleTypeIn);
             }
 
+            // array-to-string (e.g. `<string>numberArray`, real JS array.toString() semantics)
+            // confirmed to already work end-to-end via a JIT repro without ever reaching here -
+            // it must be resolved by a dedicated MLIR-level pass/pattern before this generic LLVM-
+            // lowering cast() helper runs, matching this branch's own "must be processed at MLIR
+            // pass" comment. Fail cleanly instead of crashing on the off chance some other path
+            // still reaches this with an unconverted array.
             if (auto constArrayType = dyn_cast<mlir_ts::ConstArrayType>(inType))
             {
-                llvm_unreachable("not implemented, must be processed at MLIR pass");
+                emitError(loc) << "cast from " << inType << " to " << resType << " is not supported";
                 return mlir::Value();
             }
 
             if (auto arrayType = dyn_cast<mlir_ts::ArrayType>(inType))
             {
-                llvm_unreachable("not implemented, must be processed at MLIR pass");
+                emitError(loc) << "cast from " << inType << " to " << resType << " is not supported";
                 return mlir::Value();
             }
         }
 
         if (auto interfaceTypeRes = dyn_cast<mlir_ts::InterfaceType>(resType))
         {
+            // tuple-to-interface casting (`<SomeInterface>tupleValue`) confirmed to already work
+            // end-to-end via a JIT repro without reaching here - like the array-to-string case
+            // above, it must be resolved by a dedicated MLIR-level pass (interface construction/
+            // vtable wiring) before this generic cast() helper runs. Fail cleanly instead of
+            // crashing on the off chance some other path still reaches this unconverted.
             if (auto tupleTypeIn = dyn_cast<mlir_ts::ConstTupleType>(inType))
             {
-                llvm_unreachable("not implemented, must be processed at MLIR pass");
+                emitError(loc) << "cast from " << inType << " to " << resType << " is not supported";
                 return mlir::Value();
             }
 
             if (auto tupleTypeIn = dyn_cast<mlir_ts::TupleType>(inType))
             {
-                llvm_unreachable("not implemented, must be processed at MLIR pass");
+                emitError(loc) << "cast from " << inType << " to " << resType << " is not supported";
                 return mlir::Value();
             }
         }
@@ -456,8 +467,14 @@ class CastLogicHelper
                 }
                 else
                 {
+                    // truthy-checking a union type that needs an RTTI tag (e.g. `if (x)` where
+                    // `x: number | {a: number}`) confirmed to already fail cleanly one stage
+                    // earlier - MLIRGen's own union-to-boolean cast dispatch (see
+                    // MLIRGenCast.cpp's castFromUnion, §4.9 of docs/not-implemented-audit.md)
+                    // rejects it before this LLVM-lowering helper ever runs. Fail cleanly here
+                    // too rather than crash, in case some other path still reaches this.
                     // TODO: finish it, union type has RTTI field, test it first
-                    llvm_unreachable("not implemented");
+                    emitError(loc) << "cast from " << unionType << " to " << boolType << " is not supported";
                     return mlir::Value();
                 }
             }
@@ -484,7 +501,11 @@ class CastLogicHelper
 
             LLVM_DEBUG(llvm::dbgs() << "\n\t opt cast: " << inType << "->" << resType << "\n";);
 
-            llvm_unreachable("not implemented, must be processed at MLIR pass");
+            // casting an optional to something other than its own element type: tried widening
+            // to a broader union and casting through `any` as plausible triggers, neither
+            // reached here (both resolved earlier in the pipeline) - matches this branch's own
+            // "must be processed at MLIR pass" comment. Fail cleanly rather than crash.
+            emitError(loc) << "cast from " << inType << " to " << resType << " is not supported";
             return mlir::Value();
         }
 
@@ -997,9 +1018,16 @@ class CastLogicHelper
         }        
         else
         {
+            // e.g. widening `number[]` to an `any[]` parameter: the source is itself a
+            // (non-const, non-null, non-undefined) dynamic ArrayType, which this function never
+            // handled - a real, easily-reachable gap (confirmed via a plain array-widening call),
+            // not dead code. Properly supporting it needs a runtime per-element conversion loop
+            // (`number` and boxed `any` aren't bit-compatible), which is a separate, scoped
+            // feature - fail cleanly instead of crashing for now.
             LLVM_DEBUG(llvm::dbgs() << "[castToArrayType(1)] from value: " << in << " as type: " << type << " to type: " << arrayType
                                     << "\n";);
-            llvm_unreachable("not implemented");
+            emitError(loc) << "cast from array type " << type << " to array type " << arrayType << " is not supported";
+            return mlir::Value();
         }
 
         auto ptrType = th.getPtrType();

--- a/tslang/include/TypeScript/LowerToLLVM/CodeLogicHelper.h
+++ b/tslang/include/TypeScript/LowerToLLVM/CodeLogicHelper.h
@@ -238,7 +238,13 @@ class CodeLogicHelper
         }
         else
         {
-            llvm_unreachable("not implemented");
+            // e.g. `obj.accessor++` where `accessor` is a get/set pair (confirmed via repro) -
+            // a plain field/variable increment loads through a LoadOp (handled above) and stores
+            // straight back to its reference, but an accessor has no reference to store to; it
+            // would need calling the setter with the incremented value instead. That's a real,
+            // separate feature (matches this function's own long-standing "finish it for field
+            // access" TODO) - fail cleanly instead of crashing.
+            mlir::emitError(loc, "'++'/'--' on a get/set accessor property is not supported");
         }
     }
 

--- a/tslang/include/TypeScript/LowerToLLVM/LLVMCodeHelper.h
+++ b/tslang/include/TypeScript/LowerToLLVM/LLVMCodeHelper.h
@@ -448,8 +448,13 @@ class LLVMCodeHelper : public LLVMCodeHelperBase
             llvm_unreachable("ConstTupleType must not be used in array, use normal TupleType (the same way as StringType)");
         }            
 
+        // every element type a const-folded array literal (ArrayAttr) can actually carry at this
+        // lowering stage is handled above (int/float go through the dense-attr path); tried a
+        // few plausible triggers (null elements, a mixed number|string union) and neither reached
+        // here - documented in docs/not-implemented-audit.md as likely dead rather than confirmed.
         LLVM_DEBUG(llvm::dbgs() << "type: "; originalElementType.dump(); llvm::dbgs() << "\n";);
-        llvm_unreachable("array literal is not implemented(1)");
+        op->emitError("array literal is not supported for this element type");
+        return mlir::Value();
     }
 
     mlir::Value getOrCreateGlobalArray(mlir::Type originalElementType, StringRef name, unsigned size,

--- a/tslang/include/TypeScript/LowerToLLVM/OptionalLogicHelper.h
+++ b/tslang/include/TypeScript/LowerToLLVM/OptionalLogicHelper.h
@@ -140,7 +140,11 @@ class OptionalLogicHelper
                     rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sle, leftUndefFlagValue, rightUndefFlagValue);
                 break;
             default:
-                llvm_unreachable("not implemented");
+                // opCmpCode's only caller (LowerToLLVM.cpp's LogicalBinaryOpLowering) switches
+                // on the exact same 8 comparison SyntaxKinds this switch handles above and
+                // never passes anything else; fail cleanly instead of crashing if that ever
+                // stops being true.
+                mlir::emitError(loc, "unsupported comparison operator for optional type");
             }
 
             return undefFlagCmpResult;
@@ -210,7 +214,8 @@ class OptionalLogicHelper
                 rewriter.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sle, leftUndefFlagValue, rightUndefFlagValue);
             break;
         default:
-            llvm_unreachable("not implemented");
+            // same call-site-guaranteed shape as the sibling switch above.
+            mlir::emitError(loc, "unsupported comparison operator for optional type");
         }
 
         return undefFlagCmpResult;

--- a/tslang/include/TypeScript/LowerToLLVM/UndefLogicHelper.h
+++ b/tslang/include/TypeScript/LowerToLLVM/UndefLogicHelper.h
@@ -71,7 +71,11 @@ class UndefLogicHelper
                 undefFlagCmpResult = clh.createI1ConstantOf(false);
                 break;
             default:
-                llvm_unreachable("not implemented");
+                // opCmpCode's only caller (LowerToLLVM.cpp's LogicalBinaryOpLowering) switches
+                // on the exact same 8 comparison SyntaxKinds this switch handles above and
+                // never passes anything else; fail cleanly instead of crashing if that ever
+                // stops being true.
+                op->emitError("unsupported comparison operator for undefined type");
             }
 
             return undefFlagCmpResult;
@@ -104,7 +108,8 @@ class UndefLogicHelper
                     undefFlagCmpResult = clh.createI1ConstantOf(leftUndefType ? true : false);
                     break;
                 default:
-                    llvm_unreachable("not implemented");
+                    // same call-site-guaranteed shape as the sibling switch above.
+                    op->emitError("unsupported comparison operator for undefined type");
                 }
 
                 return undefFlagCmpResult;

--- a/tslang/include/TypeScript/MLIRLogic/MLIRCodeLogic.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRCodeLogic.h
@@ -1215,7 +1215,17 @@ class MLIRPropertyAccessCodeLogic
                 [&](auto floatAttr) { typeFromAttr = mlir_ts::NumberType::get(builder.getContext()); })
             .Case<mlir::BoolAttr>(
                 [&](auto boolAttr) { typeFromAttr = mlir_ts::BooleanType::get(builder.getContext()); })
-            .Default([&](auto type) { llvm_unreachable("not implemented"); });
+            .Default([&](auto type) {
+                // TS enum members can only be string or numeric literals (string/int/float
+                // attrs cover both, bool is an extra defensive case); fail cleanly instead of
+                // crashing if some other constant attribute kind is ever produced here.
+                emitError(location, "unsupported enum member value type");
+            });
+
+        if (!typeFromAttr)
+        {
+            return mlir::Value();
+        }
 
         LLVM_DEBUG(llvm::dbgs() << "\n!! enum: " << propName << " value attr: " << valueAttr << "\n");
 
@@ -1657,7 +1667,12 @@ class MLIRPropertyAccessCodeLogic
         }
         else
         {
-            llvm_unreachable("not implemented");
+            // property access through a RefType whose element isn't a Tuple/ConstTuple; this
+            // function's only caller (MLIRGenAccessCall.cpp's property-access TypeSwitch) only
+            // reaches the RefType Case for values shaped like a mutable tuple local. Fail
+            // cleanly instead of crashing if some other RefType element shape reaches here.
+            emitError(location) << "property access on reference to type '" << refType.getElementType() << "' is not supported";
+            return mlir::Value();
         }
     }
 
@@ -1674,10 +1689,14 @@ class MLIRPropertyAccessCodeLogic
         else if (auto objectStorageType = dyn_cast<mlir_ts::ObjectStorageType>(objectType.getStorageType()))
         {
             return RefLogic(objectStorageType);
-        }        
+        }
         else
         {
-            llvm_unreachable("not implemented");
+            // a boxed ObjectType's storage type is always synthesized as one of the three cases
+            // above (see docs/object-literal-boxing-design.md) - fail cleanly instead of
+            // crashing if that ever stops being true.
+            emitError(location) << "property access on object storage type '" << objectType.getStorageType() << "' is not supported";
+            return mlir::Value();
         }
     }
 
@@ -1719,7 +1738,10 @@ class MLIRPropertyAccessCodeLogic
         }
         else
         {
-            llvm_unreachable("not implemented");
+            // a ClassType's storage type is always a ClassStorageType by construction; fail
+            // cleanly instead of crashing if that ever stops being true.
+            emitError(location) << "unsupported class storage type: " << classType.getStorageType();
+            return mlir::Value();
         }
     }
 

--- a/tslang/include/TypeScript/MLIRLogic/MLIRPrinter.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRPrinter.h
@@ -298,9 +298,13 @@ class MLIRPrinter
                 StringRef strRef(Str.data(), Str.size());
                 out << strRef.str().c_str();
             })            
-            .Default([](mlir::Attribute a) { 
+            .Default([&](mlir::Attribute a) {
+                // e.g. mlir::BoolAttr (a distinct attribute kind from IntegerAttr in this
+                // codebase, per MLIRCodeLogic.h's own separate BoolAttr/IntegerAttr cases) isn't
+                // handled above; fall back to the attribute's own default printer instead of
+                // crashing, matching this class's sibling printType's Default a few lines below.
                 LLVM_DEBUG(llvm::dbgs() << "\n!! Type print is not implemented for : " << a << "\n";);
-                llvm_unreachable("not implemented");
+                out << a;
             });
     }
 

--- a/tslang/include/TypeScript/MLIRLogic/MLIRTypeIterator.h
+++ b/tslang/include/TypeScript/MLIRLogic/MLIRTypeIterator.h
@@ -383,10 +383,18 @@ class MLIRTypeIterator
                           })                          
                           .Case<mlir_ts::NullType>([&](auto) {
                               return true;
-                          })                                                 
+                          })
                           .Case<mlir_ts::BigIntType>([&](auto) {
                               return true;
-                          })                                                 
+                          })
+                          .Case<mlir_ts::NamespaceType>([&](auto) {
+                              // a leaf type (just a name, no nested mlir::Type to recurse into) -
+                              // was missing from this switch entirely (confirmed via grep against
+                              // TypeScriptTypes.td's full type list), crashing whenever a
+                              // namespace-qualified generic reference (e.g. `NS.Box<T>`) reached
+                              // isGenericType/hasInferType/etc.
+                              return true;
+                          })
                           .Case<mlir::NoneType>([&](auto) {
                               return true;
                           })                          
@@ -399,10 +407,13 @@ class MLIRTypeIterator
                           .Case<mlir::IndexType>([&](auto) {
                               return true;
                           })     
-                          .Default([](mlir::Type t) { 
+                          .Default([](mlir::Type t) {
+                            // this switch is meant to be exhaustive over every mlir_ts type (see
+                            // the NamespaceType case just added above, confirmed missing via a
+                            // grep against TypeScriptTypes.td's full type list) - fail cleanly
+                            // rather than crash if some other type still isn't covered.
                             LLVM_DEBUG(llvm::dbgs() << "\n!! Type Iteration is not implemented for : " << t << "\n";);
-                            llvm_unreachable("not implemented");
-                            return true; 
+                            return true;
                           });
 
         return result;

--- a/tslang/lib/TypeScript/MLIRGenClasses.cpp
+++ b/tslang/lib/TypeScript/MLIRGenClasses.cpp
@@ -766,7 +766,17 @@ namespace mlirgen
         }
         
         auto fieldId = TupleFieldName(name, genContext);
-        if (auto strAttr = dyn_cast<mlir::StringAttr>(fieldId)) 
+        if (!fieldId)
+        {
+            // e.g. a computed field name (`[key] = 42;`) that doesn't resolve to a compile-time
+            // constant (getNameFromComputedPropertyName already emitted its own diagnostic in
+            // that case) - fail cleanly here instead of crashing on the null Attribute below
+            // (dyn_cast/cast require their input to be non-null; that's what dyn_cast_or_null is
+            // for, and this code wasn't using it).
+            return mlir::failure();
+        }
+
+        if (auto strAttr = dyn_cast<mlir::StringAttr>(fieldId))
         {
             if (strAttr.getValue().starts_with("#"))
             {
@@ -827,8 +837,16 @@ namespace mlirgen
         }
 
         auto fieldId = TupleFieldName(name, genContext);
+        if (!fieldId)
+        {
+            // same shape as mlirGenClassDataFieldMember's identical guard above - a computed
+            // field name that failed to resolve to a constant already got its own diagnostic
+            // from getNameFromComputedPropertyName; fail cleanly instead of crashing on the
+            // unconditional mlir::cast<StringAttr> a few lines below.
+            return mlir::failure();
+        }
 
-        if (auto strAttr = dyn_cast<mlir::StringAttr>(fieldId)) 
+        if (auto strAttr = dyn_cast<mlir::StringAttr>(fieldId))
         {
             if (strAttr.getValue().starts_with("#"))
             {
@@ -889,12 +907,20 @@ namespace mlirgen
     mlir::LogicalResult MLIRGenImpl::mlirGenClassStaticFieldMemberDynamicImport(mlir::Location location, ClassInfo::TypePtr newClassPtr, PropertyDeclaration propertyDeclaration, const GenContext &genContext)
     {
         auto fieldId = TupleFieldName(propertyDeclaration->name, genContext);
+        if (!fieldId)
+        {
+            // same shape as mlirGenClassDataFieldMember's/mlirGenClassStaticFieldMember's
+            // identical guard - fail cleanly instead of crashing on the unconditional
+            // mlir::cast<StringAttr> below.
+            return mlir::failure();
+        }
+
         auto accessLevel = getAccessLevel(propertyDeclaration);
 
         // process static field - register global
         auto fullClassStaticFieldName =
             concat(newClassPtr->fullName, mlir::cast<mlir::StringAttr>(fieldId).getValue());
-        
+
         auto staticFieldType = registerVariable(
             location, fullClassStaticFieldName, true, VariableType::Var,
             [&](mlir::Location location, const GenContext &genContext) -> TypeValueInitType {
@@ -956,6 +982,15 @@ namespace mlirgen
             }
 
             auto fieldId = TupleFieldName(parameter->name, genContext);
+            if (!fieldId)
+            {
+                // constructor parameter names can't actually be computed property names (only a
+                // plain identifier or binding pattern), so this is believed unreachable in
+                // practice - guarded anyway for consistency with this function's siblings above,
+                // since dyn_cast (unlike dyn_cast_or_null) still asserts on a null Attribute.
+                return mlir::failure();
+            }
+
             if (auto strAttr = dyn_cast<mlir::StringAttr>(fieldId)) {
                 isPrivate |= strAttr.getValue().starts_with("#");
             }

--- a/tslang/lib/TypeScript/MLIRGenClasses.cpp
+++ b/tslang/lib/TypeScript/MLIRGenClasses.cpp
@@ -588,6 +588,7 @@ namespace mlirgen
                 auto result = mlirGen(extendingType, genContext);
                 EXIT_IF_FAILED_OR_NO_VALUE(result)
                 auto baseType = V(result);
+                auto success = false;
                 mlir::TypeSwitch<mlir::Type>(baseType.getType())
                     .template Case<mlir_ts::ClassType>([&](auto baseClassType) {
                         auto baseName = baseClassType.getName().getValue();
@@ -599,8 +600,27 @@ namespace mlirgen
                         {
                             baseClassInfos.push_back(classInfo);
                         }
+
+                        success = true;
                     })
-                    .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                    .Default([&](auto type) {
+                        // e.g. `class Sub extends SomeInterface {}` - real TypeScript rejects
+                        // extending an interface (only a class/constructor value is allowed
+                        // there) but this compiler doesn't enforce that rule at the heritage-
+                        // clause level, so it reaches here instead of being caught earlier.
+                        // Confirmed via repro. The original code had no failure-tracking at all
+                        // here (unconditionally `return mlir::success()` below regardless of
+                        // which case fired) - added `success` so this diagnostic isn't silently
+                        // swallowed the way it was on first attempt (emitError alone doesn't
+                        // fail this function; verified the fix actually surfaces as a compile
+                        // error, not just a silently-succeeding no-op).
+                        emitError(loc(extendingType)) << "class cannot extend type: " << to_print(type);
+                    });
+
+                if (!success)
+                {
+                    return mlir::failure();
+                }
             }
             return mlir::success();
         }
@@ -632,7 +652,16 @@ namespace mlirgen
                             interfaceInfos.push_back({interfaceInfo, -1, false});
                         }
                     })
-                    .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                    .Default([&](auto type) {
+                        // e.g. `class X implements SomeTypeAlias` where the alias resolves to an
+                        // object-shape TupleType (`type Shape = {area(): number}`) rather than a
+                        // declared InterfaceType - real, valid, and common TypeScript (implementing
+                        // a type-alias-described shape), confirmed via repro. This compiler's
+                        // `implements` handling only accepts a genuine InterfaceType - properly
+                        // supporting a TupleType target would need synthesizing an anonymous
+                        // interface from it, a separate, scoped feature. Fail cleanly for now.
+                        emitError(loc(implementingType)) << "class cannot implement type: " << to_print(type);
+                    });
             }
         }
 
@@ -1799,7 +1828,13 @@ genContext);
                         success = true;
                     }
                 })
-                .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                .Default([&](auto type) {
+                    // same shape as mlirGenClassHeritageClause's `implements` branch above (a
+                    // type-alias-resolved TupleType target, not a genuine InterfaceType) - this
+                    // function builds the vtable definition for whatever `implements` already
+                    // registered, so it hits the same real gap from a different stage.
+                    emitError(loc(implementingType)) << "class cannot implement type: " << to_print(type);
+                });
 
             if (!success)
             {
@@ -2266,7 +2301,12 @@ genContext);
                 auto memberNamePtr = MLIRHelper::getName(propertyDeclaration->name, stringAllocator);
                 if (memberNamePtr.empty())
                 {
-                    llvm_unreachable("not implemented");
+                    // e.g. a computed property name (`[expr] = value;`) reaches here with no
+                    // plain-identifier name; tried as a repro but it hits a different, earlier
+                    // bug first (an LLVM Casting.h assertion, undocumented/unfixed - see
+                    // docs/not-implemented-audit.md), so this specific branch's reachability is
+                    // unconfirmed. Fail cleanly rather than crash regardless.
+                    emitError(loc(propertyDeclaration), "computed property name is not supported here");
                     return mlir::failure();
                 }
 
@@ -2303,7 +2343,14 @@ genContext);
                     auto propertyNamePtr = MLIRHelper::getName(parameter->name, stringAllocator);
                     if (propertyNamePtr.empty())
                     {
-                        llvm_unreachable("not implemented");
+                        // e.g. a parameter property combined with a destructuring pattern
+                        // (`constructor(public {x, y}: T) {}`) - real TS rejects this combination
+                        // (TS2369) but this compiler doesn't enforce that, so the binding pattern
+                        // reaches here with no plain-identifier name. Tried as a repro but it
+                        // crashes earlier, in MLIRGenExpressions.cpp's expression dispatcher
+                        // (fixed separately this pass), so this specific branch's reachability
+                        // is unconfirmed. Fail cleanly rather than crash regardless.
+                        emitError(loc(parameter), "a parameter property cannot use a binding pattern");
                         return mlir::failure();
                     }
 

--- a/tslang/lib/TypeScript/MLIRGenExpressions.cpp
+++ b/tslang/lib/TypeScript/MLIRGenExpressions.cpp
@@ -178,7 +178,15 @@ namespace mlirgen
             return mlir::success();
         }
 
-        llvm_unreachable("unknown expression");
+        // e.g. a constructor parameter property combined with a destructuring pattern
+        // (`constructor(public {x, y}: T) {}`) - real TypeScript rejects that combination
+        // (TS2369, parameter properties can't use a binding pattern) but this compiler doesn't
+        // enforce that check, so the pattern's ObjectBindingPattern/ArrayBindingPattern name node
+        // (not an Expression kind at all) ends up passed to this dispatcher. Fail cleanly instead
+        // of crashing rather than trying to guess every non-Expression node kind that could land
+        // here.
+        emitError(loc(expressionAST)) << "unsupported expression";
+        return ValueOrLogicalResult(mlir::failure());
     }
 
     ValueOrLogicalResult MLIRGenImpl::mlirGen(FunctionExpression functionExpressionAST, const GenContext &genContext)
@@ -527,7 +535,10 @@ namespace mlirgen
             return V(builder.create<mlir_ts::PrefixUnaryOp>(location, expressionValue.getType(),
                                                             builder.getI32IntegerAttr((int)opCode), expressionValue));
         default:
-            llvm_unreachable("not implemented");
+            // `+ - ~ ! ++ --` are the complete set of TS prefix-unary operators, all handled
+            // above; fail cleanly instead of crashing if that ever stops being true.
+            emitError(location, "unsupported prefix unary operator");
+            return ValueOrLogicalResult(mlir::failure());
         }
     }
 
@@ -549,7 +560,10 @@ namespace mlirgen
             return V(builder.create<mlir_ts::PostfixUnaryOp>(location, expressionValue.getType(),
                                                              builder.getI32IntegerAttr((int)opCode), expressionValue));
         default:
-            llvm_unreachable("not implemented");
+            // `++ --` are the complete set of TS postfix-unary operators, both handled above;
+            // fail cleanly instead of crashing if that ever stops being true.
+            emitError(location, "unsupported postfix unary operator");
+            return ValueOrLogicalResult(mlir::failure());
         }
     }
 
@@ -985,7 +999,15 @@ namespace mlirgen
             }
             else
             {
-                llvm_unreachable("not implemented");
+                // e.g. `delete obj.a` where `a` is a plain, non-optional field of a value-tuple
+                // object literal - confirmed via repro. Real TypeScript itself rejects this
+                // (TS2790: "The operand of a 'delete' operator must be optional"), since deleting
+                // a required property doesn't type-check; this compiler doesn't enforce that
+                // check, so it fell through to here instead. There's also no way to actually
+                // "delete" a field from this compiler's fixed-layout value tuple regardless
+                // (unlike a real heap object) - fail cleanly rather than crash.
+                emitError(location, "the operand of a 'delete' operator must be optional");
+                return mlir::failure();
             }
         }
 

--- a/tslang/lib/TypeScript/MLIRGenGenerics.cpp
+++ b/tslang/lib/TypeScript/MLIRGenGenerics.cpp
@@ -421,7 +421,13 @@ namespace mlirgen
                                                             recieverType, discoverReturnType, genContext);
         }
 
-        llvm_unreachable("not implemented");
+        // a plausible trigger (a generic function assigned to a variable, then called through
+        // that variable) hits a different, earlier "can't instantiate specialized function"
+        // error instead of reaching here - this specific shape (functionRefValue resolving to
+        // neither a CreateBoundFunctionOp-wrapped nor a bare SymbolRefOp) remains unconfirmed.
+        // Fail cleanly instead of crashing.
+        emitError(location, "unsupported generic function reference");
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::instantiateSpecializedFunctionTypeHelper(mlir::Location location, FunctionLikeDeclarationBase funcDecl,
@@ -539,7 +545,12 @@ namespace mlirgen
                         functionRefValue.setType(
                             mlir_ts::HybridFunctionType::get(builder.getContext(), funcType));
                     })
-                    .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                    .Default([&](auto type) {
+                        // a CreateBoundFunctionOp's result can only ever be BoundFunctionType or
+                        // HybridFunctionType by construction, both handled above; fail cleanly
+                        // instead of crashing if that ever stops being true.
+                        emitError(location) << "unsupported bound function type: " << to_print(type);
+                    });
             }
 
             symbolOp->removeAttr(GENERIC_ATTR_NAME);
@@ -908,7 +919,12 @@ namespace mlirgen
             }
             else
             {
-                llvm_unreachable("not implemented");
+                // e.g. `function foo<T>(): T { ... }` called as `foo()` - no explicit type
+                // argument and no parameters/call operands to infer `T` from. Confirmed via
+                // repro. Real TS rejects this too ("type argument cannot be inferred from
+                // usage"); fail cleanly here instead of crashing.
+                emitError(location) << "generic type arguments for '" << name << "' cannot be inferred";
+                return {mlir::failure(), mlir_ts::FunctionType(), ""};
             }
 
             // we need to wide all types when initializing function
@@ -1339,7 +1355,12 @@ namespace mlirgen
             }
             else
             {
-                llvm_unreachable("not implemented");
+                // tried `super.genericMethod(...)` as a plausible trigger (a generic method
+                // reference that isn't a plain SymbolRefOp/ThisSymbolRefOp) - it resolves via
+                // SymbolRefOp too and didn't reach here, so this branch's reachability is
+                // unconfirmed. Fail cleanly instead of crashing regardless.
+                emitError(location, "unsupported generic function reference");
+                return mlir::failure();
             }
 
             auto [result, funcType, funcSymbolName] =

--- a/tslang/lib/TypeScript/MLIRGenImpl.h
+++ b/tslang/lib/TypeScript/MLIRGenImpl.h
@@ -3200,7 +3200,10 @@ class MLIRGenImpl
                 return;
             }
 
-            llvm_unreachable("not implemented");
+            // previousConditionOrFirstBranchOp is only ever assigned a CondBranchOp or BranchOp
+            // (both cases a few lines below), both handled above; fail cleanly instead of
+            // crashing if that ever stops being true.
+            emitError(location, "unsupported switch-case jump operation");
         };
 
         // condition
@@ -3474,7 +3477,11 @@ class MLIRGenImpl
                         });
                 break;
             default:
-                llvm_unreachable("not implemented");
+                // this function's only caller (MLIRGenExpressions.cpp's PrefixUnaryExpression
+                // constant-folding fast path) guards the call with the exact same 4-operator
+                // check (+ - ~ !) as the cases above; fail cleanly instead of crashing if that
+                // guard and this switch ever drift apart.
+                emitError(location, "unsupported prefix unary operator on a constant");
         }
 
         return value;
@@ -3800,7 +3807,12 @@ class MLIRGenImpl
                 }
                 else
                 {
-                    llvm_unreachable("not implemented");
+                    // isDynamicImport (@dllimport(path) with an argument) is itself an untested
+                    // feature path with zero coverage anywhere in the test suite (see §4.10 of
+                    // docs/not-implemented-audit.md) - this crash is nested one level deeper
+                    // inside that already-untested path. Fail cleanly instead of crashing.
+                    emitError(location, "unsupported RTTI value type for dynamic import");
+                    return mlir::Value();
                 }
             }
 
@@ -4392,6 +4404,7 @@ class MLIRGenImpl
         LLVM_DEBUG(dbgs() << "\n!! right expr.: " << rightExpressionValue << "\n";);
 
         auto isTuple = false;
+        auto hasUnsupportedType = false;
         mlir::Type elementType;
         mlir_ts::TupleType tupleType;
         mlir::TypeSwitch<mlir::Type>(rightExpressionValue.getType())
@@ -4399,7 +4412,21 @@ class MLIRGenImpl
             .Case<mlir_ts::ConstArrayType>([&](auto constArrayType) { elementType = constArrayType.getElementType(); })
             .Case<mlir_ts::TupleType>([&](auto tupleType_) { isTuple = true; tupleType = tupleType_; })
             .Case<mlir_ts::ConstTupleType>([&](auto constTupleType) { isTuple = true; tupleType = mth.convertConstTupleTypeToTupleType(constTupleType); })
-            .Default([](auto type) { llvm_unreachable("not implemented"); });
+            .Default([&](auto type) {
+                // e.g. `[a, b] = "hi"` (array-destructuring from a string) - confirmed via repro.
+                // Real JS supports destructuring any iterable, but this compiler's destructuring-
+                // assignment codegen only positionally indexes Array/ConstArray/Tuple/ConstTuple;
+                // supporting String (and other iterables) would need the same per-character/
+                // iterator-protocol handling `for...of` already has elsewhere, which this
+                // assignment path never gained - a real, scoped gap, not dead code.
+                hasUnsupportedType = true;
+                emitError(location) << "array destructuring assignment is not supported for type: " << to_print(type);
+            });
+
+        if (hasUnsupportedType)
+        {
+            return mlir::failure();
+        }
 
         if (!isTuple)
         {
@@ -4515,7 +4542,14 @@ class MLIRGenImpl
             }
             else
             {
-                llvm_unreachable("not implemented");
+                // e.g. `({ a, ...rest } = obj)` - rest-destructuring in an object-destructuring
+                // assignment. Confirmed via repro. A real, genuinely missing feature (same shape
+                // as §4.2's array/union object-literal spread gap): synthesizing `rest` needs
+                // enumerating every field of `obj` not already destructured elsewhere in this
+                // pattern, which this function never implemented. Fail cleanly instead of
+                // crashing rather than attempting that here.
+                emitError(location, "rest destructuring in an object destructuring assignment is not supported");
+                return mlir::failure();
             }
         }
 
@@ -6384,10 +6418,15 @@ class MLIRGenImpl
                     .template Case<mlir_ts::TupleType>([&](auto tupleType) { 
                         fields = tupleType.getFields(); 
                     })
-                    .template Case<mlir_ts::ConstTupleType>([&](auto constTupleType) { 
-                        fields = constTupleType.getFields(); 
+                    .template Case<mlir_ts::ConstTupleType>([&](auto constTupleType) {
+                        fields = constTupleType.getFields();
                     })
-                    .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                    .Default([&](auto type) {
+                        // a custom iterator whose next() return type isn't a Tuple/ConstTuple
+                        // (e.g. `next(): any`, confirmed via repro) - not the well-formed iterator
+                        // protocol shape this function checks for; treat as "not an iterator"
+                        // rather than crash, matching this function's own bool contract.
+                    });
 
                 auto propValue = mlir::StringAttr::get(builder.getContext(), "value");
                 if (std::any_of(fields.begin(), fields.end(), [&] (auto field) { return field.id == propValue; }))
@@ -6395,8 +6434,8 @@ class MLIRGenImpl
                     return true;
                 }
             }
-        }     
-        
+        }
+
         return false;
     }
 
@@ -7094,7 +7133,12 @@ class MLIRGenImpl
                     .template Case<mlir_ts::TupleType>([&](auto tupleType) { fields = tupleType.getFields(); })
                     .template Case<mlir_ts::ConstTupleType>(
                         [&](auto constTupleType) { fields = constTupleType.getFields(); })
-                    .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                    .Default([&](auto type) {
+                        // a custom iterator whose next() return type isn't a Tuple/ConstTuple
+                        // (e.g. `next(): any`) - same shape as hasIterator's identical TypeSwitch
+                        // above; `fields` just stays empty, handled by the "no 'value' field"
+                        // branch below rather than crashing here too.
+                    });
 
                 auto propValue = mlir::StringAttr::get(builder.getContext(), "value");
                 if (std::any_of(fields.begin(), fields.end(), [&] (auto field) { return field.id == propValue; }))
@@ -7108,12 +7152,16 @@ class MLIRGenImpl
                 }
                 else
                 {
-                    llvm_unreachable("not implemented");
+                    // either the next() return type has no 'value' field, or (per the Default
+                    // case above) wasn't a Tuple/ConstTuple at all - a malformed/non-standard
+                    // iterator protocol implementation. Fail cleanly instead of crashing.
+                    emitError(location, "spread source's iterator does not implement the expected 'next(): {value, done}' shape");
+                    return mlir::failure();
                 }
 
-                return mlir::success();    
+                return mlir::success();
             }
-        }                             
+        }
 
         // DO NOT PUT before xxx.next() property otherwise ""..."" for Iterator will not work
         if (auto constTuple = dyn_cast<mlir_ts::ConstTupleType>(type))
@@ -7904,7 +7952,12 @@ class MLIRGenImpl
             }
             else
             {
-                llvm_unreachable("object literal is not implemented(1)");
+                // ObjectLiteralElementLike's grammar (PropertyAssignment |
+                // ShorthandPropertyAssignment | SpreadAssignment | MethodDeclaration |
+                // GetAccessor | SetAccessor) is fully handled above; fail cleanly instead of
+                // crashing if that ever stops being true.
+                emitError(location, "unsupported object literal member");
+                return ValueOrLogicalResult(mlir::failure());
             }
 
             assert(genContext.allowPartialResolve || itemValue);
@@ -8193,7 +8246,8 @@ class MLIRGenImpl
         }
         else
         {
-            llvm_unreachable("not implemented");
+            emitError(loc(typeParameter), "type parameter name cannot be empty");
+            return std::make_shared<TypeParameterDOM>("");
         }
     }
 
@@ -8411,7 +8465,7 @@ class MLIRGenImpl
         }
         else
         {
-            llvm_unreachable("not implemented");
+            emitError(loc(typeAliasDeclarationAST), "type alias name cannot be empty");
         }
 
         return mlir::failure();
@@ -9271,14 +9325,18 @@ class MLIRGenImpl
         if (name.empty())
         {
             auto [attr, result] = getNameFromComputedPropertyName(declarationAST->name, genContext);
-            if (mlir::failed(result))
+            // getNameFromComputedPropertyName already emits its own diagnostic on failure (or
+            // when attr isn't a name-shaped value below); leave `name` empty either way and
+            // fall through to the anonymous-name synthesis below rather than returning early -
+            // this used to `return nullptr;` here, which as a `std::string` return is UB
+            // (constructs a string from a null `const char*`, crashing in strlen) and also
+            // skipped the fallback every other empty-name case in this function relies on.
+            if (mlir::succeeded(result))
             {
-                return nullptr;
-            }
-
-            if (auto strAttr = dyn_cast_or_null<mlir::StringAttr>(attr))
-            {
-                name = strAttr.getValue();
+                if (auto strAttr = dyn_cast_or_null<mlir::StringAttr>(attr))
+                {
+                    name = strAttr.getValue();
+                }
             }
         }
 
@@ -9865,7 +9923,7 @@ class MLIRGenImpl
     }
 
     // TODO: sync it with mth.getFields
-    mlir::Type getIndexedAccessType(mlir::Type type, mlir::Type indexType, const GenContext &genContext);
+    mlir::Type getIndexedAccessType(mlir::Location location, mlir::Type type, mlir::Type indexType, const GenContext &genContext);
 
     mlir::Type getIndexedAccessType(IndexedAccessTypeNode indexedAccessTypeNode, const GenContext &genContext);
 

--- a/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
+++ b/tslang/lib/TypeScript/MLIRGenInterfaces.cpp
@@ -648,7 +648,26 @@ namespace mlirgen
                                 mlirGenInterfaceAddFieldMember(newInterfacePtr, field.id, field.type, field.isConditional, orderWeight));
                     }
                 })
-                .Default([&](auto type) { llvm_unreachable("not implemented"); });
+                .Default([&](auto type) {
+                    // e.g. `interface X extends SomeClass {}` (a real TS pattern - extending
+                    // an interface from a class's instance shape) or any other fields-bearing
+                    // type the two Cases above don't special-case (ConstTupleType, ObjectType,
+                    // ...): mth.getFields already knows how to pull fields out of all of these,
+                    // reuse it instead of hand-rolling another per-type Case.
+                    llvm::SmallVector<mlir_ts::FieldInfo> destTupleFields;
+                    if (mlir::succeeded(mth.getFields(type, destTupleFields)))
+                    {
+                        orderWeight++;
+                        success = true;
+                        for (auto field : destTupleFields)
+                            success &= mlir::succeeded(
+                                mlirGenInterfaceAddFieldMember(newInterfacePtr, field.id, field.type, field.isConditional, orderWeight));
+                    }
+                    else
+                    {
+                        emitError(loc(extendsType)) << "interface cannot extend type: " << to_print(type);
+                    }
+                });
 
             if (!success)
             {
@@ -952,7 +971,8 @@ namespace mlirgen
             }
             else
             {
-                llvm_unreachable("not implemented");
+                emitError(loc(methodSignature->name), "computed method/property name must be a string");
+                return {"", false};
             }
         }
 

--- a/tslang/lib/TypeScript/MLIRGenTypes.cpp
+++ b/tslang/lib/TypeScript/MLIRGenTypes.cpp
@@ -180,8 +180,10 @@ namespace mlirgen
             return getNeverType();
         }
 
-        llvm_unreachable("not implemented type declaration");
-        // return getAnyType();
+        // e.g. ImportType (`import("module").Foo`) - not every TypeNode kind TS's grammar
+        // allows is handled above; fail cleanly instead of crashing for whichever isn't.
+        emitError(loc(typeReferenceAST), "unsupported type");
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::getInferType(mlir::Location location, InferTypeNode inferTypeNodeAST, const GenContext &genContext)
@@ -247,7 +249,9 @@ namespace mlirgen
         auto name = MLIRHelper::getName(typeParameterDeclaration->name);
         if (name.empty())
         {
-            llvm_unreachable("not implemented");
+            // grammar requires an Identifier for a type parameter's name, so this should be
+            // unreachable; fail cleanly instead of crashing if that ever stops being true.
+            emitError(loc(typeParameterDeclaration), "type parameter name cannot be empty");
             return mlir::Type();
         }
 
@@ -273,8 +277,11 @@ namespace mlirgen
             auto val = V(result);
             return val.getType();
         }
-        
-        llvm_unreachable("not implemented");
+
+        // TS's EntityName grammar is Identifier | QualifiedName, both handled above; fail
+        // cleanly instead of crashing if this is ever reached some other way.
+        emitError(loc(node), "unsupported type name");
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::getFirstTypeFromTypeArguments(NodeArray<TypeNode> &typeArguments, const GenContext &genContext)
@@ -1469,10 +1476,12 @@ namespace mlirgen
         {
             addTypeProcessKey(litType);
         }
-        else
-        {
-            llvm_unreachable("not implemented");
-        }        
+        // else: keys isn't a literal or a union of literals (e.g. the general `string`/`number`
+        // type, as in `Record<string, V>`) - this builtin fallback can't enumerate an unbounded
+        // key set into fields. In practice this is dead: Record<K, T> is declared as a mapped
+        // type in lib.generics.ts and resolveGenericType resolves it before this fallback is
+        // ever reached (see docs/not-implemented-audit.md); kept as a no-op rather than a crash
+        // for the same reason PickTypes's analogous pickTypesProcessKey already no-ops here.
 
         return getTupleType(fields);
     }
@@ -1562,10 +1571,9 @@ namespace mlirgen
             {
                 return fieldInfo.id == litType.getValue();
             }
-            else
-            {
-                llvm_unreachable("not implemented");
-            }
+            // else: keys isn't a literal or a union of literals - same dead-in-practice shape as
+            // RecordType's addTypeProcessKey above (Omit<T,K> is itself a mapped-type alias in
+            // lib.generics.ts, resolved before this fallback is reached); no-op like its sibling.
 
             return false;
         };
@@ -1871,9 +1879,12 @@ namespace mlirgen
         {
             // TODO: finish it
             return getType(typeOperatorNode->type, genContext);
-        }        
+        }
 
-        llvm_unreachable("not implemented");
+        // unique/keyof/readonly are the only TypeOperator keywords TS's grammar allows, so this
+        // should be unreachable; fail cleanly instead of crashing if that ever stops being true.
+        emitError(loc(typeOperatorNode), "unsupported type operator");
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::getIndexedAccessTypeForArrayElement(mlir_ts::ArrayType type)
@@ -1891,7 +1902,7 @@ namespace mlirgen
         return getCharType();
     }
 
-    mlir::Type MLIRGenImpl::getIndexedAccessType(mlir::Type type, mlir::Type indexType, const GenContext &genContext)
+    mlir::Type MLIRGenImpl::getIndexedAccessType(mlir::Location location, mlir::Type type, mlir::Type indexType, const GenContext &genContext)
     {
         // in case of Generic Methods but not specialized yet
         if (auto namedGenericType = dyn_cast<mlir_ts::NamedGenericType>(type))
@@ -1906,13 +1917,18 @@ namespace mlirgen
 
         if (isa<mlir_ts::StringType>(indexType))
         {
+            // e.g. `type X = SomeObj[string]` - indexing by the general `string` type rather
+            // than a specific literal key. Real TS only allows this when the indexed type has
+            // a string index signature; this compiler's indexed-access resolution only handles
+            // literal keys. Fail cleanly instead of crashing.
             LLVM_DEBUG(llvm::dbgs() << "\n!! IndexedAccessType for : " << type << " index " << indexType << " is not implemeneted, index type should not be 'string' it should be literal type \n";);
-            llvm_unreachable("not implemented");
+            emitError(location, "indexing a type by 'string' is not supported; use a literal key");
+            return mlir::Type();
         }
 
         if (auto literalType = dyn_cast<mlir_ts::LiteralType>(type))
         {
-            return getIndexedAccessType(literalType.getElementType(), indexType, genContext);
+            return getIndexedAccessType(location, literalType.getElementType(), indexType, genContext);
         }
 
         if (auto unionType = dyn_cast<mlir_ts::UnionType>(type))
@@ -1920,7 +1936,7 @@ namespace mlirgen
             SmallVector<mlir::Type> types;
             for (auto subType : unionType)
             {
-                auto typeByKey = getIndexedAccessType(subType, indexType, genContext);
+                auto typeByKey = getIndexedAccessType(location, subType, indexType, genContext);
                 if (!typeByKey)
                 {
                     return mlir::Type();
@@ -1930,14 +1946,14 @@ namespace mlirgen
             }
 
             return getUnionType(types);
-        }        
+        }
 
         if (auto unionType = dyn_cast<mlir_ts::UnionType>(indexType))
         {
             SmallVector<mlir::Type> resolvedTypes;
             for (auto itemType : unionType.getTypes())
             {
-                auto resType = getIndexedAccessType(type, itemType, genContext);
+                auto resType = getIndexedAccessType(location, type, itemType, genContext);
                 if (!resType)
                 {
                     return mlir::Type();
@@ -1998,8 +2014,8 @@ namespace mlirgen
 
         LLVM_DEBUG(llvm::dbgs() << "\n!! IndexedAccessType for : \n\t" << type << " \n\tindex " << indexType << " is not implemeneted \n";);
 
-        llvm_unreachable("not implemented");
-        //return mlir::Type();
+        emitError(location) << "indexed access is not supported on type: " << to_print(type);
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::getIndexedAccessType(IndexedAccessTypeNode indexedAccessTypeNode, const GenContext &genContext)
@@ -2016,7 +2032,7 @@ namespace mlirgen
             return indexType;
         }
 
-        return getIndexedAccessType(type, indexType, genContext);
+        return getIndexedAccessType(loc(indexedAccessTypeNode), type, indexType, genContext);
     }
 
     mlir::Type MLIRGenImpl::getTemplateLiteralType(TemplateLiteralTypeNode templateLiteralTypeNode, const GenContext &genContext)
@@ -2201,13 +2217,18 @@ namespace mlirgen
                         }
                         else
                         {
-                            llvm_unreachable("not implemented");
+                            // remapped key (`as` clause) for this member of the union isn't a
+                            // literal - can't turn it into a field name; skip this member rather
+                            // than crash, same as the "filtering out" cases above.
+                            emitError(loc(mappedTypeNode)) << "mapped type key remapping produced a non-literal name";
                         }
                     }
                 }
                 else
                 {
-                    llvm_unreachable("not implemented");
+                    // nameType/type shape mismatch (one is a union, the other isn't) for a
+                    // remapped (`as`) mapped type key - not supported, skip rather than crash.
+                    emitError(loc(mappedTypeNode)) << "unsupported mapped type key remapping";
                 }
             }
         };
@@ -2656,9 +2677,20 @@ namespace mlirgen
 
                 types.push_back({MLIRHelper::TupleFieldName(CALL_FIELD_NAME, builder.getContext()), type, false, mlir_ts::AccessLevel::Public});
             }
+            else if (kind == SyntaxKind::GetAccessor || kind == SyntaxKind::SetAccessor)
+            {
+                // unlike InterfaceDeclaration (which has its own accessors/vtable machinery,
+                // see MLIRGenInterfaces.cpp), a TypeLiteral resolves to a plain value TupleType -
+                // there's no getter/setter dispatch representation to plug an accessor into here.
+                // A real fix needs the same kind of accessor support TupleType field access
+                // doesn't have at all yet; out of scope for a crash-to-diagnostic fix.
+                emitError(loc(typeItem), "get/set accessors in a type literal are not supported");
+                return mlir::failure();
+            }
             else
             {
-                llvm_unreachable("not implemented");
+                emitError(loc(typeItem), "unsupported type literal member");
+                return mlir::failure();
             }
         }
 
@@ -3398,7 +3430,8 @@ namespace mlirgen
 
         LLVM_DEBUG(llvm::dbgs() << "\n!! value of literal: " << value << "\n";);
 
-        llvm_unreachable("not implemented");
+        emitError(loc(literalTypeNode), "unsupported literal type");
+        return mlir::Type();
     }
 
     mlir::Type MLIRGenImpl::getOptionalType(OptionalTypeNode optionalTypeNode, const GenContext &genContext)

--- a/tslang/lib/TypeScript/MLIRGenTypes.cpp
+++ b/tslang/lib/TypeScript/MLIRGenTypes.cpp
@@ -2514,7 +2514,21 @@ namespace mlirgen
             {
                 return attrComputed;
             }
-                        
+
+            if (name == SyntaxKind::ObjectBindingPattern || name == SyntaxKind::ArrayBindingPattern)
+            {
+                // e.g. a parameter property combined with a destructuring pattern
+                // (`constructor(public {x, y}: T) {}`) - real TS rejects this combination
+                // (TS2369) but this compiler doesn't enforce that check earlier, so a
+                // BindingPattern (not a ComputedPropertyName, and MLIRHelper::getName correctly
+                // returns empty for it since it has no simple name) reaches here. `name.as
+                // <Expression>()` below is only valid for actual Expression-kind names - a
+                // BindingPattern isn't one, and forcing the cast crashes (confirmed via repro:
+                // "dyn_cast on a non-existent value"). Fail cleanly instead.
+                emitError(loc(name), "a binding pattern cannot be used as a field name");
+                return mlir::Attribute();
+            }
+
             MLIRCodeLogic mcl(builder, compileOptions);
             auto result = mlirGen(name.as<Expression>(), genContext);
             auto value = V(result);

--- a/tslang/lib/TypeScriptExceptionPass/Win32ExceptionPass.cpp
+++ b/tslang/lib/TypeScriptExceptionPass/Win32ExceptionPass.cpp
@@ -581,7 +581,11 @@ struct Win32ExceptionPassCode
         }
         else
         {
-            llvm_unreachable("not implemented");
+            // every CatchRegion gets exactly one of catchPad/cleanupPad set, at the same site
+            // that first identifies it (both branches above set one or the other, never
+            // neither) - same invariant this file already asserts elsewhere (lines 393, 426)
+            // rather than crashing via llvm_unreachable; match that existing convention.
+            assert(catchRegion.catchPad || catchRegion.cleanupPad);
         }
 
         return opBundle;


### PR DESCRIPTION
## Summary

Continues the ongoing `llvm_unreachable("not implemented")` crash audit (see `docs/not-implemented-audit.md`). This PR closes:

- **§5.1** — the last remaining named/specific markers (`MLIRGenImpl.h`'s last 2 sites, `MLIRGenInterfaces.cpp`'s remaining 2, all 10 of `MLIRGenTypes.cpp`, `LLVMCodeHelper.h:452`)
- **§5.2** — every generic `TypeSwitch::Default`/switch fallback this audit had inventoried, across 12 files (`CastLogicHelper.h`, `MLIRGenClasses.cpp`, `MLIRGenExpressions.cpp`, `MLIRGenGenerics.cpp`, `MLIRGenImpl.h`'s remaining cluster, `CodeLogicHelper.h`, `OptionalLogicHelper.h`, `UndefLogicHelper.h`, `MLIRCodeLogic.h`, `MLIRPrinter.h`, `MLIRTypeIterator.h`, `Win32ExceptionPass.cpp`)

### Real, confirmed crashes fixed
- Widening `number[]` to an `any[]` parameter
- `class extends <interface>` / `class implements <type-alias>` (naming the wrong kind of type in a heritage clause)
- `obj.accessor++`/`--` on a get/set accessor property (the oldest documented gap in the audit — its own `// TODO: finish it for field access` predates this whole effort)
- `foo<T>(): T` called as `foo()` with nothing to infer `T` from
- Array-destructuring from a string (`[a, b] = "hi"`) and object rest-destructuring (`({a, ...rest} = obj)`)
- Spreading a custom iterator whose `next()` isn't a well-formed `{value, done}` shape
- Non-string computed interface method names, `Foo[string]` indexed access, type-literal get/set accessors
- A `getNameWithArguments` UB crash (`return nullptr;` constructing a `std::string`, found via WinDbg while chasing an unrelated repro)

### Notable finds
- Two heritage-clause/destructuring fixes each surfaced a **second bug**: the original code had no failure-tracking at all in its `TypeSwitch` loop, so the first attempt's `emitError` was silently swallowed until a `success` flag was added.
- `MLIRTypeIterator.h` (this compiler's most widely-called recursive type-walker) was missing a `NamespaceType` case entirely — found by diffing against `TypeScriptTypes.td`'s type list rather than reproducing a crash.
- Two bugs were found but deliberately **not** fixed here (different category, noted in the doc for a future pass): an LLVM `Casting.h` assertion reachable via a computed class-property initializer, and a delete-expression crash that reproduced once and then never again.

Full per-site real/dead/unconfirmed breakdown is in `docs/not-implemented-audit.md` (§4.12-§4.13).

## Test plan
- [x] `ctest -C Debug -j8` → 829/829 passing, re-verified after every file's fixes throughout both passes (not just once at the end)
- [x] Each confirmed-crash repro re-run clean (no crash, clean diagnostic) after its fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)